### PR TITLE
feat: add OTLP protobuf to OTAP conversion for metrics

### DIFF
--- a/rust/otap-dataflow/crates/otap/src/encoder.rs
+++ b/rust/otap-dataflow/crates/otap/src/encoder.rs
@@ -4,6 +4,12 @@
 use otap_df_pdata_views::views::{
     common::{AnyValueView, AttributeView, InstrumentationScopeView, ValueType},
     logs::{LogRecordView, LogsDataView, ResourceLogsView, ScopeLogsView},
+    metrics::{
+        BucketsView, DataView, ExemplarView, ExponentialHistogramDataPointView,
+        ExponentialHistogramView, GaugeView, HistogramDataPointView, HistogramView, MetricView,
+        MetricsView, NumberDataPointView, ResourceMetricsView, ScopeMetricsView, SumView,
+        SummaryDataPointView, SummaryView, ValueAtQuantileView,
+    },
     resource::ResourceView,
     trace::{
         EventView, LinkView, ResourceSpansView, ScopeSpansView, SpanView, StatusView, TracesView,
@@ -13,9 +19,15 @@ use otel_arrow_rust::{
     encode::record::{
         attributes::{AttributesRecordBatchBuilder, AttributesRecordBatchBuilderConstructorHelper},
         logs::LogsRecordBatchBuilder,
+        metrics::{
+            BucketsRecordBatchBuilder, ExemplarsRecordBatchBuilder,
+            ExponentialHistogramDataPointsRecordBatchBuilder,
+            HistogramDataPointsRecordBatchBuilder, MetricsRecordBatchBuilder,
+            NumberDataPointsRecordBatchBuilder, SummaryDataPointsRecordBatchBuilder,
+        },
         spans::{EventsBuilder, LinksBuilder, SpansRecordBatchBuilder},
     },
-    otap::{Logs, OtapBatch, Traces},
+    otap::{Logs, Metrics, OtapBatch, Traces},
     otlp::attributes::parent_id::ParentId,
     proto::opentelemetry::arrow::v1::ArrowPayloadType,
 };
@@ -546,6 +558,407 @@ where
     }
 
     Ok(())
+}
+
+// A helper function to centralize handling `Exemplar` data since we use it in several places.
+fn append_exemplar<View>(
+    exemplar: &mut ExemplarsRecordBatchBuilder,
+    exemplar_view: &View,
+    curr_id: &mut u32,
+    parent_id: &u32,
+    attrs: &mut AttributesRecordBatchBuilder<u32>,
+) -> Result<()>
+where
+    View: ExemplarView,
+{
+    exemplar.append_id(*curr_id);
+    exemplar.append_parent_id(*parent_id);
+    exemplar.append_time_unix_nano(exemplar_view.time_unix_nano() as i64);
+
+    let double = exemplar_view.value().and_then(|v| v.as_double());
+    let integer = exemplar_view.value().and_then(|v| v.as_integer());
+    // FIXME: OTAP defines these fields as non-nullable, but the data is
+    // inherently nullable coming from OTLP....
+    exemplar.append_double_value(double.unwrap_or(0.));
+    exemplar.append_int_value(integer.unwrap_or(0));
+
+    exemplar.append_span_id(exemplar_view.span_id().unwrap_or(&[0; 8]))?;
+    exemplar.append_trace_id(exemplar_view.trace_id().unwrap_or(&[0; 16]))?;
+
+    for kv in exemplar_view.filtered_attributes() {
+        attrs.append_parent_id(curr_id);
+        append_attribute_value(attrs, &kv)?;
+    }
+
+    *curr_id = curr_id.checked_add(1).ok_or(Error::U32OverflowError)?;
+    Ok(())
+}
+
+/// A helper function to append ExponentialHistogramDataPoint Bucket data
+fn append_ehdp_bucket<View>(
+    view: Option<&View>,
+    builder: &mut BucketsRecordBatchBuilder,
+    scratch: &mut Vec<u64>,
+) where
+    View: BucketsView,
+{
+    let buckets = view.map(|v| {
+        scratch.clear();
+        scratch.extend(v.bucket_counts());
+        (v.offset(), &scratch[..])
+    });
+    builder.append(buckets)
+}
+
+/// A helper function to centralize handling NumberDataPoint data for the Gauge and Sum cases.
+fn append_ndp<View>(
+    ndp: &mut NumberDataPointsRecordBatchBuilder,
+    ndp_view: &View,
+    curr_metric_id: &u16,
+    curr_ndp_id: &mut u32,
+    attrs: &mut AttributesRecordBatchBuilder<u32>,
+) -> Result<()>
+where
+    View: NumberDataPointView,
+{
+    ndp.append_id(*curr_ndp_id);
+    ndp.append_parent_id(*curr_metric_id);
+    ndp.append_start_time_unix_nano(Some(ndp_view.start_time_unix_nano() as i64));
+    ndp.append_time_unix_nano(ndp_view.time_unix_nano() as i64);
+    let double = ndp_view.value().and_then(|v| v.as_double());
+    let integer = ndp_view.value().and_then(|v| v.as_integer());
+    ndp.append_double_value(double);
+    ndp.append_int_value(integer);
+    ndp.append_flags(ndp_view.flags().into_inner());
+
+    for kv in ndp_view.attributes() {
+        attrs.append_parent_id(curr_ndp_id);
+        append_attribute_value(attrs, &kv)?;
+    }
+
+    *curr_ndp_id = curr_ndp_id.checked_add(1).ok_or(Error::U32OverflowError)?;
+    Ok(())
+}
+
+/// Traverse the metrics structure within the MetricsView and produces an `OtapBatch` for the
+/// metrics data.
+pub fn encode_metrics_otap_batch<T>(metrics_view: &T) -> Result<OtapBatch>
+where
+    T: MetricsView,
+{
+    let mut resource_attrs = AttributesRecordBatchBuilder::<u16>::new();
+    let mut scope_attrs = AttributesRecordBatchBuilder::<u16>::new();
+    let mut metric_attrs = AttributesRecordBatchBuilder::<u16>::new();
+
+    // variables for storing `NumberDataPoint` data
+    let mut curr_ndp_id: u32 = 0;
+    let mut ndp = NumberDataPointsRecordBatchBuilder::new();
+    let mut ndp_attrs = AttributesRecordBatchBuilder::<u32>::new();
+    // variables for storing `Exemplar` data associated with `NumberDataPoint`
+    let mut curr_ndpe_id: u32 = 0;
+    let mut ndpe = ExemplarsRecordBatchBuilder::new();
+    let mut ndpe_attrs = AttributesRecordBatchBuilder::<u32>::new();
+
+    // `HistogramDataPoints` support
+    let mut curr_hdp_id: u32 = 0;
+    let mut hdp = HistogramDataPointsRecordBatchBuilder::new();
+    let mut hdp_attrs = AttributesRecordBatchBuilder::<u32>::new();
+    // `Exemplars` associated wtih `HistogramDataPoints`
+    let mut curr_hdpe_id: u32 = 0;
+    let mut hdpe = ExemplarsRecordBatchBuilder::new();
+    let mut hdpe_attrs = AttributesRecordBatchBuilder::<u32>::new();
+
+    // `Summary` handling...
+    let mut curr_summary_id: u32 = 0;
+    let mut summary = SummaryDataPointsRecordBatchBuilder::new();
+    let mut summary_attrs = AttributesRecordBatchBuilder::<u32>::new();
+
+    // `ExponentialHistogramDataPoint` support...
+    let mut curr_ehdp_id: u32 = 0;
+    let mut ehdp = ExponentialHistogramDataPointsRecordBatchBuilder::new();
+    let mut ehdp_attrs = AttributesRecordBatchBuilder::<u32>::new();
+    // `Exemplars` associated wtih `ExponentialHistogramDataPoint`
+    let mut curr_ehdpe_id: u32 = 0;
+    let mut ehdpe = ExemplarsRecordBatchBuilder::new();
+    let mut ehdpe_attrs = AttributesRecordBatchBuilder::<u32>::new();
+
+    let mut metrics = MetricsRecordBatchBuilder::new();
+    let mut curr_resource_id: u16 = 0;
+    let mut curr_scope_id: u16 = 0;
+    let mut curr_metric_id: u16 = 0;
+
+    // These are scratch buffers so we don't have to reallocate a new one everytime we need
+    // one. They're used to ease conversion between iterators and slices.
+    let mut scratch_u64: Vec<u64> = Vec::new();
+    let mut scratch_f64: Vec<f64> = Vec::new();
+
+    for resource_metric in metrics_view.resources() {
+        if let Some(resource) = resource_metric.resource() {
+            metrics.resource.append_id(Some(curr_resource_id));
+            for kv in resource.attributes() {
+                resource_attrs.append_parent_id(&curr_resource_id);
+                append_attribute_value(&mut resource_attrs, &kv)?;
+            }
+        }
+
+        for scope_metric in resource_metric.scopes() {
+            let metric_count = scope_metric.metrics().count();
+            let scope_schema_url = scope_metric.schema_url();
+            (0..metric_count).for_each(|_| metrics.append_scope_schema_url(scope_schema_url));
+
+            let scope = scope_metric.scope();
+            let scope_name = scope.as_ref().and_then(|s| s.name());
+            let scope_version = scope.as_ref().and_then(|s| s.version());
+            (0..metric_count).for_each(|_| metrics.scope.append_id(Some(curr_scope_id)));
+            (0..metric_count).for_each(|_| metrics.scope.append_name(scope_name));
+            (0..metric_count).for_each(|_| metrics.scope.append_version(scope_version));
+            if let Some(scope) = scope {
+                for kv in scope.attributes() {
+                    scope_attrs.append_parent_id(&curr_scope_id);
+                    append_attribute_value(&mut scope_attrs, &kv)?;
+                }
+            }
+
+            for metric in scope_metric.metrics() {
+                metrics.append_id(curr_metric_id);
+                let data_obj = metric.data();
+                let data = data_obj.as_ref();
+                // Note: `metric_type` is not optional in the OTAP schema and it is required in the
+                // OTLP `Data` enum, but `Data` is optional for `Metric`, which means it might not
+                // exist. Should we panic or use a different sentinel value for that case?
+                metrics.append_metric_type(data.map(|data| data.value_type() as u8).unwrap_or(0));
+                metrics.append_name(metric.name());
+                metrics.append_description(metric.description());
+                metrics.append_unit(metric.unit());
+
+                let aggregation_temporality = data.and_then(|data| {
+                    let sum = data.as_sum().map(|sum| sum.aggregation_temporality());
+                    let hist = data
+                        .as_histogram()
+                        .map(|hist| hist.aggregation_temporality());
+                    let exp = data
+                        .as_exponential_histogram()
+                        .map(|exp| exp.aggregation_temporality());
+                    sum.or(hist).or(exp)
+                });
+
+                metrics
+                    .append_aggregation_temporality(aggregation_temporality.map(|agg| agg as i32));
+
+                let is_monotonic =
+                    data.and_then(|data| data.as_sum().map(|sum| sum.is_monotonic()));
+                metrics.append_is_monotonic(is_monotonic);
+
+                for kv in metric.metadata() {
+                    metric_attrs.append_parent_id(&curr_resource_id);
+                    append_attribute_value(&mut metric_attrs, &kv)?;
+                }
+
+                if let Some(data) = data_obj {
+                    // FIXME: is there no way to make enums play nicely with our view
+                    // implementations so we can match instead of engaging in this abomination?
+
+                    if let Some(gauge) = data.as_gauge() {
+                        for ndp_view in gauge.data_points() {
+                            // exemplars have to be handled first since `append_ndp` will increment
+                            // `curr_ndp_id`.
+                            for exemplar in ndp_view.exemplars() {
+                                append_exemplar(
+                                    &mut ndpe,
+                                    &exemplar,
+                                    &mut curr_ndpe_id,
+                                    &curr_ndp_id,
+                                    &mut ndpe_attrs,
+                                )?;
+                            }
+
+                            append_ndp(
+                                &mut ndp,
+                                &ndp_view,
+                                &curr_metric_id,
+                                &mut curr_ndp_id,
+                                &mut ndp_attrs,
+                            )?;
+                        }
+                    } else if let Some(sum) = data.as_sum() {
+                        for ndp_view in sum.data_points() {
+                            // exemplars have to be handled first since `append_ndp` will increment
+                            // `curr_ndp_id`.
+                            for exemplar in ndp_view.exemplars() {
+                                append_exemplar(
+                                    &mut ndpe,
+                                    &exemplar,
+                                    &mut curr_ndpe_id,
+                                    &curr_ndp_id,
+                                    &mut ndpe_attrs,
+                                )?;
+                            }
+
+                            append_ndp(
+                                &mut ndp,
+                                &ndp_view,
+                                &curr_metric_id,
+                                &mut curr_ndp_id,
+                                &mut ndp_attrs,
+                            )?;
+                        }
+                    } else if let Some(histogram) = data.as_histogram() {
+                        for hdp_view in histogram.data_points() {
+                            for kv in hdp_view.attributes() {
+                                hdp_attrs.append_parent_id(&curr_hdp_id);
+                                append_attribute_value(&mut hdp_attrs, &kv)?;
+                            }
+
+                            for exemplar in hdp_view.exemplars() {
+                                append_exemplar(
+                                    &mut hdpe,
+                                    &exemplar,
+                                    &mut curr_hdpe_id,
+                                    &curr_hdp_id,
+                                    &mut hdpe_attrs,
+                                )?;
+                            }
+
+                            hdp.append_id(curr_hdp_id);
+                            hdp.append_parent_id(curr_metric_id);
+                            hdp.append_start_time_unix_nano(hdp_view.start_time_unix_nano() as i64);
+                            hdp.append_time_unix_nano(hdp_view.time_unix_nano() as i64);
+                            hdp.append_count(hdp_view.count());
+                            scratch_u64.clear();
+                            scratch_u64.extend(hdp_view.bucket_counts());
+                            hdp.append_bucket_counts(&scratch_u64);
+                            scratch_f64.clear();
+                            scratch_f64.extend(hdp_view.explicit_bounds());
+                            hdp.append_explicit_bounds(&scratch_f64);
+                            hdp.append_sum(hdp_view.sum());
+                            hdp.append_flags(hdp_view.flags().into_inner());
+                            hdp.append_min(hdp_view.min());
+                            hdp.append_max(hdp_view.max());
+
+                            curr_hdp_id =
+                                curr_hdp_id.checked_add(1).ok_or(Error::U32OverflowError)?;
+                        }
+                    } else if let Some(exponential_histogram) = data.as_exponential_histogram() {
+                        for ehdp_view in exponential_histogram.data_points() {
+                            for kv in ehdp_view.attributes() {
+                                ehdp_attrs.append_parent_id(&curr_ehdp_id);
+                                append_attribute_value(&mut ehdp_attrs, &kv)?;
+                            }
+                            ehdp.append_id(curr_ehdp_id);
+                            ehdp.append_parent_id(curr_metric_id);
+                            ehdp.append_start_time_unix_nano(
+                                ehdp_view.start_time_unix_nano() as i64
+                            );
+                            ehdp.append_time_unix_nano(ehdp_view.time_unix_nano() as i64);
+                            ehdp.append_count(ehdp_view.count());
+                            ehdp.append_sum(ehdp_view.sum());
+                            ehdp.append_scale(ehdp_view.scale());
+                            ehdp.append_zero_count(ehdp_view.zero_count());
+                            ehdp.append_flags(ehdp_view.flags().into_inner());
+                            ehdp.append_min(ehdp_view.min());
+                            ehdp.append_max(ehdp_view.max());
+
+                            for exemplar in ehdp_view.exemplars() {
+                                append_exemplar(
+                                    &mut ehdpe,
+                                    &exemplar,
+                                    &mut curr_ehdpe_id,
+                                    &curr_ehdp_id,
+                                    &mut ehdpe_attrs,
+                                )?;
+                            }
+                            append_ehdp_bucket(
+                                ehdp_view.positive().as_ref(),
+                                &mut ehdp.positive,
+                                &mut scratch_u64,
+                            );
+                            append_ehdp_bucket(
+                                ehdp_view.negative().as_ref(),
+                                &mut ehdp.negative,
+                                &mut scratch_u64,
+                            );
+
+                            curr_ehdp_id =
+                                curr_ehdp_id.checked_add(1).ok_or(Error::U32OverflowError)?;
+                        }
+                    } else if let Some(summary_view) = data.as_summary() {
+                        for sdp_view in summary_view.data_points() {
+                            for kv in sdp_view.attributes() {
+                                summary_attrs.append_parent_id(&curr_summary_id);
+                                append_attribute_value(&mut summary_attrs, &kv)?;
+                            }
+
+                            summary.append_id(curr_summary_id);
+                            summary.append_parent_id(curr_metric_id);
+                            summary.append_start_time_unix_nano(sdp_view.start_time_unix_nano() as i64);
+                            summary.append_time_unix_nano(sdp_view.time_unix_nano() as i64);
+                            summary.append_count(sdp_view.count());
+                            summary.append_sum(sdp_view.sum());
+                            summary.append_flags(sdp_view.flags().into_inner());
+
+                            for qv in sdp_view.quantile_values() {
+                                summary.quantile_values.append_quantile(qv.quantile());
+                                summary.quantile_values.append_value(qv.value());
+                            }
+
+                            curr_summary_id = curr_summary_id
+                                .checked_add(1)
+                                .ok_or(Error::U32OverflowError)?;
+                        }
+                    }
+                }
+
+                curr_metric_id = curr_metric_id
+                    .checked_add(1)
+                    .ok_or(Error::U16OverflowError)?;
+            }
+            curr_scope_id = curr_scope_id
+                .checked_add(1)
+                .ok_or(Error::U16OverflowError)?;
+        }
+        curr_resource_id = curr_resource_id
+            .checked_add(1)
+            .ok_or(Error::U16OverflowError)?;
+    }
+
+    let mut otap_batch = OtapBatch::Metrics(Metrics::default());
+    otap_batch.set(ArrowPayloadType::UnivariateMetrics, metrics.finish()?);
+
+    // FIXME: there doesn't seem to be a payload type for Metrics' attrs.
+    let pairs = [
+        (resource_attrs.finish()?, ArrowPayloadType::ResourceAttrs),
+        (scope_attrs.finish()?, ArrowPayloadType::ScopeAttrs),
+        (ndp.finish()?, ArrowPayloadType::NumberDataPoints),
+        (ndp_attrs.finish()?, ArrowPayloadType::NumberDpAttrs),
+        (ndpe.finish()?, ArrowPayloadType::NumberDpExemplars),
+        (
+            ndpe_attrs.finish()?,
+            ArrowPayloadType::NumberDpExemplarAttrs,
+        ),
+        (hdp.finish()?, ArrowPayloadType::HistogramDataPoints),
+        (hdp_attrs.finish()?, ArrowPayloadType::HistogramDpAttrs),
+        (hdpe.finish()?, ArrowPayloadType::HistogramDpExemplars),
+        (
+            hdpe_attrs.finish()?,
+            ArrowPayloadType::HistogramDpExemplarAttrs,
+        ),
+        (ehdp.finish()?, ArrowPayloadType::ExpHistogramDataPoints),
+        (ehdp_attrs.finish()?, ArrowPayloadType::ExpHistogramDpAttrs),
+        (ehdpe.finish()?, ArrowPayloadType::ExpHistogramDpExemplars),
+        (
+            ehdpe_attrs.finish()?,
+            ArrowPayloadType::ExpHistogramDpExemplarAttrs,
+        ),
+        (summary.finish()?, ArrowPayloadType::SummaryDataPoints),
+        (summary_attrs.finish()?, ArrowPayloadType::SummaryDpAttrs),
+    ];
+    for (rb, payload_type) in pairs {
+        if rb.num_rows() > 0 {
+            otap_batch.set(payload_type, rb);
+        }
+    }
+
+    Ok(otap_batch)
 }
 
 #[cfg(test)]

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/proto.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/proto.rs
@@ -5,6 +5,7 @@
 
 pub mod common;
 pub mod logs;
+pub mod metrics;
 pub mod resource;
 pub mod trace;
 mod wrappers;

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/proto.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/proto.rs
@@ -7,3 +7,4 @@ pub mod common;
 pub mod logs;
 pub mod resource;
 pub mod trace;
+mod wrappers;

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/proto/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/proto/metrics.rs
@@ -1,0 +1,704 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains the implementation of the pdata View traits for proto message structs
+//! from otlp metrics.proto.
+
+use otel_arrow_rust::proto::opentelemetry::metrics::v1::{
+    Exemplar, ExponentialHistogram, ExponentialHistogramDataPoint, Gauge, Histogram,
+    HistogramDataPoint, Metric, MetricsData, NumberDataPoint, ResourceMetrics, ScopeMetrics, Sum,
+    Summary, SummaryDataPoint, exponential_histogram_data_point::Buckets, metric::Data,
+    summary_data_point::ValueAtQuantile,
+};
+
+use crate::otlp::proto::common::{
+    KeyValueIter, ObjInstrumentationScope, ObjKeyValue, parse_span_id, parse_trace_id,
+};
+use crate::otlp::proto::resource::ObjResource;
+use crate::otlp::proto::wrappers::{GenericIterator, GenericObj, Wraps};
+use crate::views::common::{SpanId, Str, TraceId};
+use crate::views::metrics::{
+    BucketsView, DataPointFlags, DataType, DataView, ExemplarView,
+    ExponentialHistogramDataPointView, ExponentialHistogramView, GaugeView, HistogramDataPointView,
+    HistogramView, MetricView, MetricsView, NumberDataPointView, ResourceMetricsView,
+    ScopeMetricsView, SumView, SummaryDataPointView, SummaryView, Value, ValueAtQuantileView,
+};
+
+/* ───────────────────────────── VIEW WRAPPERS (zero-alloc) ────────────── */
+
+/// A wrapper for references to `ResourceMetrics`.
+pub type ObjResourceMetrics<'a> = GenericObj<'a, ResourceMetrics>;
+
+/// A wrapper for references to `ScopeMetrics`.
+pub type ObjScopeMetrics<'a> = GenericObj<'a, ScopeMetrics>;
+
+/// A wrapper for references to `Metric`.
+pub type ObjMetric<'a> = GenericObj<'a, Metric>;
+
+/// A wrapper for references to `Data`.
+pub type ObjData<'a> = GenericObj<'a, Data>;
+
+/// A wrapper for references to `Gauge`.
+pub type ObjGauge<'a> = GenericObj<'a, Gauge>;
+
+/// A wrapper for references to `Sum`.
+pub type ObjSum<'a> = GenericObj<'a, Sum>;
+
+/// A wrapper for references to `Histogram`.
+pub type ObjHistogram<'a> = GenericObj<'a, Histogram>;
+
+/// A wrapper for references to `ExponentialHistogram`
+pub type ObjExponentialHistogram<'a> = GenericObj<'a, ExponentialHistogram>;
+
+/// A wrapper for references to `Summary`.
+pub type ObjSummary<'a> = GenericObj<'a, Summary>;
+
+/// A wrapper for references to `NumberDataPoint`.
+pub type ObjNumberDataPoint<'a> = GenericObj<'a, NumberDataPoint>;
+
+/// A wrapper for references to `Exemplar`.
+pub type ObjExemplar<'a> = GenericObj<'a, Exemplar>;
+
+/// A wrapper for references to `SummaryDataPoint`.
+pub type ObjSummaryDataPoint<'a> = GenericObj<'a, SummaryDataPoint>;
+
+/// A wrapper for references to `HistogramDataPoint`.
+pub type ObjHistogramDataPoint<'a> = GenericObj<'a, HistogramDataPoint>;
+
+/// A wrapper for references to `ExponentialHistogramDataPoint`.
+pub type ObjExponentialHistogramDataPoint<'a> = GenericObj<'a, ExponentialHistogramDataPoint>;
+
+/// A wrapper for references to `Buckets`.
+pub type ObjBuckets<'a> = GenericObj<'a, Buckets>;
+
+/// A wrapper for references to `ValueAtQuantile`.
+pub type ObjValueAtQuantile<'a> = GenericObj<'a, ValueAtQuantile>;
+
+/* ───────────────────────────── ADAPTER ITERATORS ─────────────────────── */
+
+/// An iterator for `ObjResourceMetrics`; it consumes a slice iterator of `ResourceMetrics`.
+pub type ResourceMetricsIter<'a> = GenericIterator<'a, ResourceMetrics, ObjResourceMetrics<'a>>;
+
+/// An iterator for `ObjScopeMetrics`; it consumes a slice iterator of `ScopeMetrics`.
+pub type ScopeMetricsIter<'a> = GenericIterator<'a, ScopeMetrics, ObjScopeMetrics<'a>>;
+
+/// An iterator for `ObjMetric`; it consumes a slice iterator of `Metric`s.
+pub type MetricIter<'a> = GenericIterator<'a, Metric, ObjMetric<'a>>;
+
+/// An iterator for `ObjNumberDataPoint`; it consumes a slice iterator of `NumberDataPoint`s.
+pub type NumberDataPointIter<'a> = GenericIterator<'a, NumberDataPoint, ObjNumberDataPoint<'a>>;
+
+/// An iterator for `ObjExemplar`; it consumes a slice iterator of `Exemplar`s.
+pub type ExemplarIter<'a> = GenericIterator<'a, Exemplar, ObjExemplar<'a>>;
+
+/// An iterator for `ObjSummaryDataPoint`; it consumes a slice iterator of `SummaryDataPoint`.
+pub type SummaryDataPointIter<'a> = GenericIterator<'a, SummaryDataPoint, ObjSummaryDataPoint<'a>>;
+
+/// An iterator for `ObjHistogramDataPoint`; it consumes a slice iterator of `HistogramDataPoint`.
+pub type HistogramDataPointIter<'a> =
+    GenericIterator<'a, HistogramDataPoint, ObjHistogramDataPoint<'a>>;
+
+/// An iterator for `ObjExponentialHistogramDataPoint`; it consumes a slice iterator of
+/// `ExponentialHistogramDataPoint`.
+pub type ExponentialHistogramDataPointIter<'a> =
+    GenericIterator<'a, ExponentialHistogramDataPoint, ObjExponentialHistogramDataPoint<'a>>;
+
+/// An iterator for `ObjValueAtQuantile`; it consumes a slice iterator of `ValueAtQuantile`.
+pub type ValueAtQuantileIter<'a> = GenericIterator<'a, ValueAtQuantile, ObjValueAtQuantile<'a>>;
+
+/* ───────────────────────────── TRAIT IMPLEMENTATIONS ─────────────────── */
+
+impl MetricsView for MetricsData {
+    type ResourceMetrics<'res>
+        = ObjResourceMetrics<'res>
+    where
+        Self: 'res;
+
+    type ResourceMetricsIter<'res>
+        = ResourceMetricsIter<'res>
+    where
+        Self: 'res;
+
+    fn resources(&self) -> Self::ResourceMetricsIter<'_> {
+        ResourceMetricsIter::new(self.resource_metrics.iter())
+    }
+}
+
+impl ResourceMetricsView for ObjResourceMetrics<'_> {
+    type Resource<'res>
+        = ObjResource<'res>
+    where
+        Self: 'res;
+
+    type ScopeMetrics<'scp>
+        = ObjScopeMetrics<'scp>
+    where
+        Self: 'scp;
+
+    type ScopesIter<'scp>
+        = ScopeMetricsIter<'scp>
+    where
+        Self: 'scp;
+
+    fn resource(&self) -> Option<Self::Resource<'_>> {
+        self.inner.resource.as_ref().map(ObjResource::new)
+    }
+
+    fn scopes(&self) -> Self::ScopesIter<'_> {
+        ScopeMetricsIter::new(self.inner.scope_metrics.iter())
+    }
+
+    fn schema_url(&self) -> Str<'_> {
+        &self.inner.schema_url
+    }
+}
+
+impl ScopeMetricsView for ObjScopeMetrics<'_> {
+    type Scope<'scp>
+        = ObjInstrumentationScope<'scp>
+    where
+        Self: 'scp;
+
+    type Metric<'met>
+        = ObjMetric<'met>
+    where
+        Self: 'met;
+
+    type MetricIter<'met>
+        = MetricIter<'met>
+    where
+        Self: 'met;
+
+    fn scope(&self) -> Option<Self::Scope<'_>> {
+        self.inner.scope.as_ref().map(ObjInstrumentationScope::new)
+    }
+
+    fn metrics(&self) -> Self::MetricIter<'_> {
+        MetricIter::new(self.inner.metrics.iter())
+    }
+
+    fn schema_url(&self) -> Str<'_> {
+        &self.inner.schema_url
+    }
+}
+
+impl MetricView for ObjMetric<'_> {
+    type Data<'dat>
+        = ObjData<'dat>
+    where
+        Self: 'dat;
+
+    type Attribute<'att>
+        = ObjKeyValue<'att>
+    where
+        Self: 'att;
+
+    type AttributeIter<'att>
+        = KeyValueIter<'att>
+    where
+        Self: 'att;
+
+    fn name(&self) -> Str<'_> {
+        &self.inner.name
+    }
+
+    fn description(&self) -> Str<'_> {
+        &self.inner.description
+    }
+
+    fn unit(&self) -> Str<'_> {
+        &self.inner.unit
+    }
+
+    fn data(&self) -> Option<Self::Data<'_>> {
+        self.inner.data.as_ref().map(ObjData::new)
+    }
+
+    fn metadata(&self) -> Self::AttributeIter<'_> {
+        KeyValueIter::new(self.inner.metadata.iter())
+    }
+}
+
+impl DataView<'_> for ObjData<'_> {
+    type NumberDataPoint<'dp>
+        = ObjNumberDataPoint<'dp>
+    where
+        Self: 'dp;
+
+    type NumberDataPointIter<'dp>
+        = NumberDataPointIter<'dp>
+    where
+        Self: 'dp;
+
+    type Gauge<'gauge>
+        = ObjGauge<'gauge>
+    where
+        Self: 'gauge;
+
+    type Sum<'sum>
+        = ObjSum<'sum>
+    where
+        Self: 'sum;
+
+    type Histogram<'histogram>
+        = ObjHistogram<'histogram>
+    where
+        Self: 'histogram;
+
+    type ExponentialHistogram<'exp>
+        = ObjExponentialHistogram<'exp>
+    where
+        Self: 'exp;
+
+    type Summary<'summary>
+        = ObjSummary<'summary>
+    where
+        Self: 'summary;
+
+    fn value_type(&self) -> DataType {
+        self.inner.into()
+    }
+
+    fn as_gauge(&self) -> Option<Self::Gauge<'_>> {
+        match self.inner {
+            Data::Gauge(gauge) => Some(ObjGauge::new(gauge)),
+            _ => None,
+        }
+    }
+
+    fn as_sum(&self) -> Option<Self::Sum<'_>> {
+        match self.inner {
+            Data::Sum(sum) => Some(ObjSum::new(sum)),
+            _ => None,
+        }
+    }
+
+    fn as_histogram(&self) -> Option<Self::Histogram<'_>> {
+        match self.inner {
+            Data::Histogram(histogram) => Some(ObjHistogram::new(histogram)),
+            _ => None,
+        }
+    }
+
+    fn as_exponential_histogram(&self) -> Option<Self::ExponentialHistogram<'_>> {
+        match self.inner {
+            Data::ExponentialHistogram(exp) => Some(ObjExponentialHistogram::new(exp)),
+            _ => None,
+        }
+    }
+
+    fn as_summary(&self) -> Option<Self::Summary<'_>> {
+        match self.inner {
+            Data::Summary(summary) => Some(ObjSummary::new(summary)),
+            _ => None,
+        }
+    }
+}
+
+impl GaugeView for ObjGauge<'_> {
+    type NumberDataPoint<'dp>
+        = ObjNumberDataPoint<'dp>
+    where
+        Self: 'dp;
+
+    type NumberDataPointIter<'dp>
+        = NumberDataPointIter<'dp>
+    where
+        Self: 'dp;
+
+    fn data_points(&self) -> Self::NumberDataPointIter<'_> {
+        NumberDataPointIter::new(self.inner.data_points.iter())
+    }
+}
+
+impl NumberDataPointView for ObjNumberDataPoint<'_> {
+    type Attribute<'att>
+        = ObjKeyValue<'att>
+    where
+        Self: 'att;
+
+    type AttributeIter<'att>
+        = KeyValueIter<'att>
+    where
+        Self: 'att;
+
+    type Exemplar<'ex>
+        = ObjExemplar<'ex>
+    where
+        Self: 'ex;
+
+    type ExemplarIter<'ex>
+        = ExemplarIter<'ex>
+    where
+        Self: 'ex;
+
+    fn start_time_unix_nano(&self) -> u64 {
+        self.inner.start_time_unix_nano
+    }
+
+    fn time_unix_nano(&self) -> u64 {
+        self.inner.time_unix_nano
+    }
+
+    fn value(&self) -> Option<Value> {
+        self.inner.value.as_ref().map(Value::from)
+    }
+
+    fn attributes(&self) -> Self::AttributeIter<'_> {
+        KeyValueIter::new(self.inner.attributes.iter())
+    }
+
+    fn exemplars(&self) -> Self::ExemplarIter<'_> {
+        ExemplarIter::new(self.inner.exemplars.iter())
+    }
+
+    fn flags(&self) -> DataPointFlags {
+        DataPointFlags::new(self.inner.flags)
+    }
+}
+
+impl ExemplarView for ObjExemplar<'_> {
+    type Attribute<'att>
+        = ObjKeyValue<'att>
+    where
+        Self: 'att;
+
+    type AttributeIter<'att>
+        = KeyValueIter<'att>
+    where
+        Self: 'att;
+
+    fn filtered_attributes(&self) -> Self::AttributeIter<'_> {
+        KeyValueIter::new(self.inner.filtered_attributes.iter())
+    }
+
+    fn time_unix_nano(&self) -> u64 {
+        self.inner.time_unix_nano
+    }
+
+    fn value(&self) -> Option<Value> {
+        self.inner.value.as_ref().map(Value::from)
+    }
+
+    fn span_id(&self) -> Option<&SpanId> {
+        parse_span_id(&self.inner.span_id)
+    }
+
+    fn trace_id(&self) -> Option<&TraceId> {
+        parse_trace_id(&self.inner.trace_id)
+    }
+}
+
+impl SumView for ObjSum<'_> {
+    type NumberDataPoint<'dp>
+        = ObjNumberDataPoint<'dp>
+    where
+        Self: 'dp;
+
+    type NumberDataPointIter<'dp>
+        = NumberDataPointIter<'dp>
+    where
+        Self: 'dp;
+
+    fn data_points(&self) -> Self::NumberDataPointIter<'_> {
+        NumberDataPointIter::new(self.inner.data_points.iter())
+    }
+
+    fn aggregation_temporality(&self) -> crate::views::metrics::AggregationTemporality {
+        self.inner.aggregation_temporality().into()
+    }
+
+    fn is_monotonic(&self) -> bool {
+        self.inner.is_monotonic
+    }
+}
+
+impl HistogramView for ObjHistogram<'_> {
+    type HistogramDataPoint<'dp>
+        = ObjHistogramDataPoint<'dp>
+    where
+        Self: 'dp;
+
+    type HistogramDataPointIter<'dp>
+        = HistogramDataPointIter<'dp>
+    where
+        Self: 'dp;
+
+    fn data_points(&self) -> Self::HistogramDataPointIter<'_> {
+        HistogramDataPointIter::new(self.inner.data_points.iter())
+    }
+
+    fn aggregation_temporality(&self) -> crate::views::metrics::AggregationTemporality {
+        self.inner.aggregation_temporality().into()
+    }
+}
+
+impl HistogramDataPointView for ObjHistogramDataPoint<'_> {
+    type Attribute<'att>
+        = ObjKeyValue<'att>
+    where
+        Self: 'att;
+
+    type AttributeIter<'att>
+        = KeyValueIter<'att>
+    where
+        Self: 'att;
+
+    type BucketCountIter<'bc>
+        = std::slice::Iter<'bc, u64>
+    where
+        Self: 'bc;
+
+    type ExplicitBoundsIter<'eb>
+        = std::slice::Iter<'eb, f64>
+    where
+        Self: 'eb;
+
+    type Exemplar<'ex>
+        = ObjExemplar<'ex>
+    where
+        Self: 'ex;
+
+    type ExemplarIter<'ex>
+        = ExemplarIter<'ex>
+    where
+        Self: 'ex;
+
+    fn attributes(&self) -> Self::AttributeIter<'_> {
+        KeyValueIter::new(self.inner.attributes.iter())
+    }
+
+    fn start_time_unix_nano(&self) -> u64 {
+        self.inner.start_time_unix_nano
+    }
+
+    fn time_unix_nano(&self) -> u64 {
+        self.inner.time_unix_nano
+    }
+
+    fn count(&self) -> u64 {
+        self.inner.count
+    }
+
+    fn sum(&self) -> Option<f64> {
+        self.inner.sum
+    }
+
+    fn bucket_counts(&self) -> Self::BucketCountIter<'_> {
+        self.inner.bucket_counts.iter()
+    }
+
+    fn explicit_bounds(&self) -> Self::ExplicitBoundsIter<'_> {
+        self.inner.explicit_bounds.iter()
+    }
+
+    fn exemplars(&self) -> Self::ExemplarIter<'_> {
+        ExemplarIter::new(self.inner.exemplars.iter())
+    }
+
+    fn flags(&self) -> DataPointFlags {
+        DataPointFlags::new(self.inner.flags)
+    }
+
+    fn min(&self) -> Option<f64> {
+        self.inner.min
+    }
+
+    fn max(&self) -> Option<f64> {
+        self.inner.max
+    }
+}
+
+impl ValueAtQuantileView for ObjValueAtQuantile<'_> {
+    fn quantile(&self) -> f64 {
+        self.inner.quantile
+    }
+
+    fn value(&self) -> f64 {
+        self.inner.value
+    }
+}
+
+impl ExponentialHistogramView for ObjExponentialHistogram<'_> {
+    type ExponentialHistogramDataPoint<'edp>
+        = ObjExponentialHistogramDataPoint<'edp>
+    where
+        Self: 'edp;
+
+    type ExponentialHistogramDataPointIter<'edp>
+        = ExponentialHistogramDataPointIter<'edp>
+    where
+        Self: 'edp;
+
+    fn data_points(&self) -> Self::ExponentialHistogramDataPointIter<'_> {
+        ExponentialHistogramDataPointIter::new(self.inner.data_points.iter())
+    }
+
+    fn aggregation_temporality(&self) -> crate::views::metrics::AggregationTemporality {
+        self.inner.aggregation_temporality().into()
+    }
+}
+
+impl ExponentialHistogramDataPointView for ObjExponentialHistogramDataPoint<'_> {
+    type Attribute<'att>
+        = ObjKeyValue<'att>
+    where
+        Self: 'att;
+
+    type AttributeIter<'att>
+        = KeyValueIter<'att>
+    where
+        Self: 'att;
+
+    type Buckets<'b>
+        = ObjBuckets<'b>
+    where
+        Self: 'b;
+
+    type Exemplar<'ex>
+        = ObjExemplar<'ex>
+    where
+        Self: 'ex;
+
+    type ExemplarIter<'ex>
+        = ExemplarIter<'ex>
+    where
+        Self: 'ex;
+
+    fn attributes(&self) -> Self::AttributeIter<'_> {
+        KeyValueIter::new(self.inner.attributes.iter())
+    }
+
+    fn start_time_unix_nano(&self) -> u64 {
+        self.inner.start_time_unix_nano
+    }
+
+    fn time_unix_nano(&self) -> u64 {
+        self.inner.time_unix_nano
+    }
+
+    fn count(&self) -> u64 {
+        self.inner.count
+    }
+
+    fn sum(&self) -> Option<f64> {
+        self.inner.sum
+    }
+
+    fn scale(&self) -> i32 {
+        self.inner.scale
+    }
+
+    fn zero_count(&self) -> u64 {
+        self.inner.zero_count
+    }
+
+    fn positive(&self) -> Option<Self::Buckets<'_>> {
+        self.inner.positive.as_ref().map(ObjBuckets::new)
+    }
+
+    fn negative(&self) -> Option<Self::Buckets<'_>> {
+        self.inner.negative.as_ref().map(ObjBuckets::new)
+    }
+
+    fn flags(&self) -> DataPointFlags {
+        DataPointFlags::new(self.inner.flags)
+    }
+
+    fn exemplars(&self) -> Self::ExemplarIter<'_> {
+        ExemplarIter::new(self.inner.exemplars.iter())
+    }
+
+    fn min(&self) -> Option<f64> {
+        self.inner.min
+    }
+
+    fn max(&self) -> Option<f64> {
+        self.inner.max
+    }
+
+    fn zero_threshold(&self) -> f64 {
+        self.inner.zero_threshold
+    }
+}
+
+impl BucketsView for ObjBuckets<'_> {
+    type BucketCountIter<'bc>
+        = std::slice::Iter<'bc, u64>
+    where
+        Self: 'bc;
+
+    fn offset(&self) -> i32 {
+        self.inner.offset
+    }
+
+    fn bucket_counts(&self) -> Self::BucketCountIter<'_> {
+        self.inner.bucket_counts.iter()
+    }
+}
+
+impl SummaryView for ObjSummary<'_> {
+    type SummaryDataPoint<'dp>
+        = ObjSummaryDataPoint<'dp>
+    where
+        Self: 'dp;
+
+    type SummaryDataPointIter<'dp>
+        = SummaryDataPointIter<'dp>
+    where
+        Self: 'dp;
+
+    fn data_points(&self) -> Self::SummaryDataPointIter<'_> {
+        SummaryDataPointIter::new(self.inner.data_points.iter())
+    }
+}
+
+impl SummaryDataPointView for ObjSummaryDataPoint<'_> {
+    type Attribute<'att>
+        = ObjKeyValue<'att>
+    where
+        Self: 'att;
+
+    type AttributeIter<'att>
+        = KeyValueIter<'att>
+    where
+        Self: 'att;
+
+    type ValueAtQuantile<'vaq>
+        = ObjValueAtQuantile<'vaq>
+    where
+        Self: 'vaq;
+
+    type ValueAtQuantileIter<'vaq>
+        = ValueAtQuantileIter<'vaq>
+    where
+        Self: 'vaq;
+
+    fn attributes(&self) -> Self::AttributeIter<'_> {
+        KeyValueIter::new(self.inner.attributes.iter())
+    }
+
+    fn start_time_unix_nano(&self) -> u64 {
+        self.inner.start_time_unix_nano
+    }
+
+    fn time_unix_nano(&self) -> u64 {
+        self.inner.time_unix_nano
+    }
+
+    fn count(&self) -> u64 {
+        self.inner.count
+    }
+
+    fn sum(&self) -> f64 {
+        self.inner.sum
+    }
+
+    fn quantile_values(&self) -> Self::ValueAtQuantileIter<'_> {
+        ValueAtQuantileIter::new(self.inner.quantile_values.iter())
+    }
+
+    fn flags(&self) -> DataPointFlags {
+        DataPointFlags::new(self.inner.flags)
+    }
+}

--- a/rust/otap-dataflow/crates/pdata-views/src/otlp/proto/wrappers.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/otlp/proto/wrappers.rs
@@ -1,0 +1,84 @@
+//! To ensure design flexibility, we want to introduce a layer of abstraction over access to OTLP
+//! data. That's a bit tricky beacuse OTLP structures are object trees with iterators for different
+//! child structures. This module gives you some convenient tools to create indirection types. For
+//! example, for the OTLP struct `ResourceSpans`, we can construct a wrapper that holds references
+//! to it like this:
+//!
+//! ```compile_fail
+//! // These doctests are marked as failing because we want this module to be private and you can't
+//! // doctest non-public items.
+//! pub type ObjResourceSpans<'a> = GenericObj<'a, ResourceSpans>;
+//! ```
+//!
+//! We can then create an iterator struct that consumes slice iterators of `ResourceSpans` and
+//! yields elements of `ObjResourceSpans` like so:
+//! ```compile_fail
+//! pub type ResourceIter<'a> = GenericIterator<'a, ResourceSpans, ObjResourceSpans<'a>>;
+//! ```
+use std::{marker::PhantomData, slice};
+
+/// A generic iterator that can wrap the `std::slice::Iter` for any type `Inner` with lifetime
+/// `'a`. This iterator yields elements of type `Outer`. Given that it starts with an `Inner` and
+/// must yield `Outer` elements, how does that work? Well, it only works because `Inner` and `Outer`
+/// are related by the `Wraps` trait which ensures that given an instance of type `Inner`, we can
+/// always construct a corresponding instance of type `Outer`.
+#[derive(Clone)]
+pub struct GenericIterator<'a, Inner, Outer> {
+    it: slice::Iter<'a, Inner>,
+    _outer: PhantomData<Outer>,
+}
+
+impl<'a, Inner, Outer> GenericIterator<'a, Inner, Outer> {
+    /// Make a new `GenericIterator` given a slice iterator over `Inner`s.
+    #[must_use]
+    pub fn new(it: slice::Iter<'a, Inner>) -> Self {
+        Self {
+            it,
+            _outer: PhantomData,
+        }
+    }
+}
+
+/// Any type `T` that implements `Wraps<'a, Inner>` guarantees that given a reference with lifetime
+/// `'a` to a `Inner`, we can make an instance of `T` that stores that reference.
+pub trait Wraps<'a, Inner> {
+    /// Construct a new instance of `Self` given a reference to a value of type `Inner`.
+    fn new(inner: &'a Inner) -> Self;
+}
+
+// Now we have all the pieces needed to make `GenericIterator` an iterator.
+impl<'a, Inner, Outer> Iterator for GenericIterator<'a, Inner, Outer>
+where
+    Outer: Wraps<'a, Inner>,
+{
+    type Item = Outer;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.it.next().map(Outer::new)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.it.size_hint()
+    }
+
+    // FIXME: would there be any performance benefit to using a macro crate to delegate all the
+    // default `Iterator` methods directly to `self.it`? We'd get the same results either way, but
+    // maybe the optimizer would do better if we didn't have to continually dereference
+    // `self.it.next()`?
+}
+
+/// `GenericObj` is a wrapper for storing references to some type `Inner`.
+#[derive(Clone)]
+pub struct GenericObj<'a, Inner> {
+    /// The reference that we're wrapping
+    pub inner: &'a Inner,
+}
+
+// Of course, `GenericObj` implements `Wraps` for, well, everything.
+impl<'a, Inner> Wraps<'a, Inner> for GenericObj<'a, Inner> {
+    fn new(inner: &'a Inner) -> Self {
+        GenericObj { inner }
+    }
+}

--- a/rust/otap-dataflow/crates/pdata-views/src/views.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/views.rs
@@ -5,6 +5,7 @@
 
 pub mod common;
 pub mod logs;
+pub mod metrics;
 pub mod resource;
 pub mod trace;
 

--- a/rust/otap-dataflow/crates/pdata-views/src/views/metrics.rs
+++ b/rust/otap-dataflow/crates/pdata-views/src/views/metrics.rs
@@ -1,0 +1,705 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! **Backend-agnostic, zero-copy view traits for OTLP Metrics.**
+//!
+//! ```text
+//! MetricsData
+//! └─── ResourceMetrics
+//!   ├── Resource
+//!   ├── SchemaURL
+//!   └── ScopeMetrics
+//!      ├── Scope
+//!      ├── SchemaURL
+//!      └── Metric
+//!         ├── Name
+//!         ├── Description
+//!         ├── Unit
+//!         └── data
+//!            ├── Gauge
+//!            ├── Sum
+//!            ├── Histogram
+//!            ├── ExponentialHistogram
+//!            └── Summary
+//! ```
+
+use otel_arrow_rust::proto::opentelemetry::metrics::v1 as proto;
+
+use crate::views::{
+    common::{AttributeView, InstrumentationScopeView, SpanId, Str, TraceId},
+    resource::ResourceView,
+};
+
+/// View for top level MetricsData
+pub trait MetricsView {
+    /// The `ResourcesMetricsView` type associated with this implementation.
+    type ResourceMetrics<'res>: ResourceMetricsView
+    where
+        Self: 'res;
+
+    /// The `ResourceMetrics` iterator type associated with this implementation.
+    type ResourceMetricsIter<'res>: Iterator<Item = Self::ResourceMetrics<'res>>
+    where
+        Self: 'res;
+
+    /// Iterator yielding borrowed references to ResourceMetrics wrappers.
+    fn resources(&self) -> Self::ResourceMetricsIter<'_>;
+}
+
+/// View for ResourceMetrics
+pub trait ResourceMetricsView {
+    /// The `ResourceView` trait associated with this impl of the `ResourceMetricsView` trait.
+    type Resource<'res>: ResourceView
+    where
+        Self: 'res;
+
+    /// The `ScopeMetricsView` trait associated with this impl of the `ResourceMetricsView`.
+    type ScopeMetrics<'scp>: ScopeMetricsView
+    where
+        Self: 'scp;
+
+    /// The `ScopeMetrics` iterator type associated with this implementation.
+    type ScopesIter<'scp>: Iterator<Item = Self::ScopeMetrics<'scp>>
+    where
+        Self: 'scp;
+
+    /// Access the resource
+    fn resource(&self) -> Option<Self::Resource<'_>>;
+
+    /// Iterator yielding the `ScopeMetrics` that originate from this Resource.
+    fn scopes(&self) -> Self::ScopesIter<'_>;
+
+    /// The schema URL for the resource.
+    fn schema_url(&self) -> Str<'_>;
+}
+
+/// View for ScopeMetrics
+pub trait ScopeMetricsView {
+    /// The `InstrumentationScopeView` trait associated with this implementation.
+    type Scope<'scp>: InstrumentationScopeView
+    where
+        Self: 'scp;
+
+    /// The `MetricsView` trait associated with this implementation.
+    type Metric<'met>: MetricView
+    where
+        Self: 'met;
+
+    /// The associated iterator type for this impl of the trait.
+    type MetricIter<'met>: Iterator<Item = Self::Metric<'met>>
+    where
+        Self: 'met;
+
+    /// Access the instrumentation scope for the metrics contained in this scope.
+    fn scope(&self) -> Option<Self::Scope<'_>>;
+
+    /// Iterator yielding the `Metrics` that originate from this resource.
+    fn metrics(&self) -> Self::MetricIter<'_>;
+
+    /// The schema URL for the resource.
+    fn schema_url(&self) -> Str<'_>;
+}
+
+/// View for Metric
+pub trait MetricView {
+    /// The `DataView` type associated with this impl of the `MetricView` trait.
+    type Data<'dat>: DataView<'dat>
+    where
+        Self: 'dat;
+
+    /// The `AttributeView` type associated with this implementation.
+    type Attribute<'att>: AttributeView
+    where
+        Self: 'att;
+
+    /// Iterator type for yielding attributes.
+    type AttributeIter<'att>: Iterator<Item = Self::Attribute<'att>>
+    where
+        Self: 'att;
+
+    /// Access the metric's name
+    fn name(&self) -> Str<'_>;
+
+    /// Access the metric's description
+    fn description(&self) -> Str<'_>;
+
+    /// Access the metric's unit
+    fn unit(&self) -> Str<'_>;
+
+    /// Access the metric's data
+    fn data(&self) -> Option<Self::Data<'_>>;
+
+    /// Access the metric's attributes
+    fn metadata(&self) -> Self::AttributeIter<'_>;
+}
+
+/// Enum representing the type of some DataType
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DataType {
+    /// Gauge represents the type of a scalar metric that always exports the "current value" for
+    /// every data point.
+    Gauge = 5,
+
+    /// Sum represents the type of a scalar metric that is calculated as a sum of all reported
+    /// measurements over a time interval.
+    Sum = 7,
+
+    /// Histogram represents the type of a metric that is calculated by aggregating as a Histogram
+    /// of all reported measurements over a time interval.
+    Histogram = 9,
+
+    /// ExponentialHistogram represents the type of a metric that is calculated by aggregating as a
+    /// ExponentialHistogram of all reported double measurements over a time interval.
+    ExponentialHistogram = 10,
+
+    /// Summary metric data are used to convey quantile summaries.
+    Summary = 11,
+}
+
+impl From<&proto::metric::Data> for DataType {
+    fn from(value: &proto::metric::Data) -> Self {
+        use proto::metric::Data::*;
+        match value {
+            Gauge(_) => DataType::Gauge,
+            Sum(_) => DataType::Sum,
+            Histogram(_) => DataType::Histogram,
+            ExponentialHistogram(_) => DataType::ExponentialHistogram,
+            Summary(_) => DataType::Summary,
+        }
+    }
+}
+
+/// View for Data
+pub trait DataView<'val> {
+    /// The `NumberDataPointView` type associated with this implementation.
+    type NumberDataPoint<'dp>: NumberDataPointView
+    where
+        Self: 'dp;
+
+    /// An iterator type that yields instances of Self::NumberDataPoint.
+    type NumberDataPointIter<'dp>: Iterator<Item = Self::NumberDataPoint<'dp>>
+    where
+        Self: 'dp;
+
+    /// A type that wraps references to `Gauge`
+    type Gauge<'gauge>: GaugeView
+    where
+        Self: 'gauge;
+
+    /// A type that wraps references to `Sum`
+    type Sum<'sum>: SumView
+    where
+        Self: 'sum;
+
+    /// A type that wraps references to `Histogram`
+    type Histogram<'histogram>: HistogramView
+    where
+        Self: 'histogram;
+
+    /// A type that wraps references to `ExponentialHistogram`
+    type ExponentialHistogram<'exp>: ExponentialHistogramView
+    where
+        Self: 'exp;
+
+    /// A type that wraps references to `Summary`
+    type Summary<'summary>: SummaryView
+    where
+        Self: 'summary;
+
+    /// The type of this Data element
+    fn value_type(&self) -> DataType;
+
+    /// Get the Gauge value
+    fn as_gauge(&self) -> Option<Self::Gauge<'_>>;
+
+    /// Get the Sum value
+    fn as_sum(&self) -> Option<Self::Sum<'_>>;
+
+    /// Get the Histogram value
+    fn as_histogram(&self) -> Option<Self::Histogram<'_>>;
+
+    /// Get the ExpoenentialHistogram value
+    fn as_exponential_histogram(&self) -> Option<Self::ExponentialHistogram<'_>>;
+
+    /// Get the Summary value
+    fn as_summary(&self) -> Option<Self::Summary<'_>>;
+}
+
+/// View for Gauge
+pub trait GaugeView {
+    /// The `NumberDataPointView` type associated with this implementation.
+    type NumberDataPoint<'dp>: NumberDataPointView
+    where
+        Self: 'dp;
+
+    /// An iterator type that yields instances of Self::NumberDataPoint.
+    type NumberDataPointIter<'dp>: Iterator<Item = Self::NumberDataPoint<'dp>>
+    where
+        Self: 'dp;
+
+    /// Access the Gauge's data points
+    fn data_points(&self) -> Self::NumberDataPointIter<'_>;
+}
+
+/// View for Sum
+pub trait SumView {
+    /// The `NumberDataPointView` type associated with this implementation.
+    type NumberDataPoint<'dp>: NumberDataPointView
+    where
+        Self: 'dp;
+
+    /// An iterator type that yields instances of Self::NumberDataPoint.
+    type NumberDataPointIter<'dp>: Iterator<Item = Self::NumberDataPoint<'dp>>
+    where
+        Self: 'dp;
+
+    /// Access the Sum's data points
+    fn data_points(&self) -> Self::NumberDataPointIter<'_>;
+
+    /// Access the Sum's aggregation temporality
+    fn aggregation_temporality(&self) -> AggregationTemporality;
+
+    /// Access the Sum's monotonicity
+    fn is_monotonic(&self) -> bool;
+}
+
+/// View for NumberDataPoint
+pub trait NumberDataPointView {
+    /// The `AttributeView` type associated with this implementation.
+    type Attribute<'att>: AttributeView
+    where
+        Self: 'att;
+
+    /// Iterator type for yielding attributes.
+    type AttributeIter<'att>: Iterator<Item = Self::Attribute<'att>>
+    where
+        Self: 'att;
+
+    /// The `ExemplarView` type associated with this implementation.
+    type Exemplar<'ex>: ExemplarView
+    where
+        Self: 'ex;
+
+    /// Iteratory type for yielding Exemplar wrappers.
+    type ExemplarIter<'ex>: Iterator<Item = Self::Exemplar<'ex>>
+    where
+        Self: 'ex;
+
+    /// Access the start time
+    fn start_time_unix_nano(&self) -> u64;
+
+    /// Access the time
+    fn time_unix_nano(&self) -> u64;
+
+    /// Access data
+    fn value(&self) -> Option<Value>;
+
+    /// Access the point's attributes
+    fn attributes(&self) -> Self::AttributeIter<'_>;
+
+    /// Access the point's exemplars
+    fn exemplars(&self) -> Self::ExemplarIter<'_>;
+
+    /// Get the flags
+    fn flags(&self) -> DataPointFlags;
+}
+
+/// The value of the measurement that was recorded.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Value {
+    /// A double value
+    Double(f64),
+
+    /// An integer value
+    Integer(i64),
+}
+
+impl Value {
+    /// Fetch a double option.
+    #[must_use]
+    pub fn as_double(&self) -> Option<f64> {
+        match self {
+            Self::Double(x) => Some(*x),
+            _ => None,
+        }
+    }
+
+    /// Fetch an integer option.
+    #[must_use]
+    pub fn as_integer(&self) -> Option<i64> {
+        match self {
+            Self::Integer(x) => Some(*x),
+            _ => None,
+        }
+    }
+}
+
+impl From<&proto::exemplar::Value> for Value {
+    fn from(value: &proto::exemplar::Value) -> Self {
+        use proto::exemplar::Value::*;
+        match value {
+            AsDouble(d) => Value::Double(*d),
+            AsInt(i) => Value::Integer(*i),
+        }
+    }
+}
+
+impl From<&proto::number_data_point::Value> for Value {
+    fn from(value: &proto::number_data_point::Value) -> Self {
+        use proto::number_data_point::Value::*;
+        match value {
+            AsDouble(d) => Value::Double(*d),
+            AsInt(i) => Value::Integer(*i),
+        }
+    }
+}
+
+/// View for Exemplar
+pub trait ExemplarView {
+    /// The `AttributeView` type associated with this implementation.
+    type Attribute<'att>: AttributeView
+    where
+        Self: 'att;
+
+    /// Iterator type for yielding attributes.
+    type AttributeIter<'att>: Iterator<Item = Self::Attribute<'att>>
+    where
+        Self: 'att;
+
+    /// Get the filtered attributes
+    fn filtered_attributes(&self) -> Self::AttributeIter<'_>;
+
+    /// Access the time
+    fn time_unix_nano(&self) -> u64;
+
+    /// Access data
+    fn value(&self) -> Option<Value>;
+
+    /// Access the span ID. Should return None if the underlying span ID is missing or if the
+    /// backend representation of the span ID is invalid. Invalid span IDs include all-0s or a
+    /// span ID or incorrect length (length != 8)
+    fn span_id(&self) -> Option<&SpanId>;
+
+    /// Access the trace ID. Should return None if the underlying trace ID is missing, or if the
+    /// backend representation of the trace ID is invalid. Invalid trace IDs include all-0s or a
+    /// trace ID of incorrect length (length != 16)
+    fn trace_id(&self) -> Option<&TraceId>;
+}
+
+/// View for Summary
+pub trait SummaryView {
+    /// The `SummaryDataPointView` type associated with this implementation.
+    type SummaryDataPoint<'dp>: SummaryDataPointView
+    where
+        Self: 'dp;
+
+    /// Iterator type for yielding data points.
+    type SummaryDataPointIter<'dp>: Iterator<Item = Self::SummaryDataPoint<'dp>>
+    where
+        Self: 'dp;
+
+    /// Access the Summary's data points
+    fn data_points(&self) -> Self::SummaryDataPointIter<'_>;
+}
+
+/// View for SummaryDataPoint
+pub trait SummaryDataPointView {
+    /// The `AttributeView` type associated with this implementation.
+    type Attribute<'att>: AttributeView
+    where
+        Self: 'att;
+
+    /// Iterator type for yielding attributes.
+    type AttributeIter<'att>: Iterator<Item = Self::Attribute<'att>>
+    where
+        Self: 'att;
+
+    /// The `ValueAtQuantileView` type associated with this implementation.
+    type ValueAtQuantile<'vaq>: ValueAtQuantileView
+    where
+        Self: 'vaq;
+
+    /// Iterator type for yielding ValueAtQuantiles.
+    type ValueAtQuantileIter<'vaq>: Iterator<Item = Self::ValueAtQuantile<'vaq>>
+    where
+        Self: 'vaq;
+
+    /// Get the attributes
+    fn attributes(&self) -> Self::AttributeIter<'_>;
+
+    /// Access the start time
+    fn start_time_unix_nano(&self) -> u64;
+
+    /// Access the time
+    fn time_unix_nano(&self) -> u64;
+
+    /// Get the count
+    fn count(&self) -> u64;
+
+    /// Get the sum
+    fn sum(&self) -> f64;
+
+    /// Get quantile values
+    fn quantile_values(&self) -> Self::ValueAtQuantileIter<'_>;
+
+    /// Get the flags
+    fn flags(&self) -> DataPointFlags;
+}
+
+/// View for ValueAtQuantile
+pub trait ValueAtQuantileView {
+    /// The quantile of a distribution. Must be in the interval [0.0, 1.0].
+    fn quantile(&self) -> f64;
+
+    /// The value at the given quantile of a distribution.
+    ///
+    /// Quantile values must NOT be negative.
+    fn value(&self) -> f64;
+}
+
+/// DataPointFlags
+pub struct DataPointFlags(u32);
+
+impl DataPointFlags {
+    /// Make a new instance
+    #[must_use]
+    pub fn new(flags: u32) -> DataPointFlags {
+        DataPointFlags(flags)
+    }
+
+    /// This DataPoint is valid but has no recorded value. This value SHOULD be used to reflect
+    /// explicitly missing data in a series, as for an equivalent to the Prometheus "staleness
+    /// marker".
+    #[must_use]
+    pub fn no_recorded_value(&self) -> bool {
+        self.0 & 1 != 0
+    }
+
+    /// Return the raw flags value.
+    #[must_use]
+    pub fn into_inner(self) -> u32 {
+        self.0
+    }
+}
+
+// FIXME: the `DataPointFlags` enum specifies `repr(i32)` but the field definition in the message
+// types uses `u32`.
+
+/// AggregationTemporality defines how a metric aggregator reports aggregated values. It describes
+/// how those values relate to the time interval over which they are aggregated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AggregationTemporality {
+    /// UNSPECIFIED is the default AggregationTemporality, it MUST not be used.
+    Unspecified = 0,
+
+    /// DELTA is an AggregationTemporality for a metric aggregator which reports changes since last
+    /// report time. Successive metrics contain aggregation of values from continuous and
+    /// non-overlapping intervals.
+    Delta = 1,
+
+    /// CUMULATIVE is an AggregationTemporality for a metric aggregator which reports changes since
+    /// a fixed start time.
+    Cumulative = 2,
+}
+
+impl From<proto::AggregationTemporality> for AggregationTemporality {
+    fn from(value: proto::AggregationTemporality) -> Self {
+        use AggregationTemporality::*;
+        match value {
+            proto::AggregationTemporality::Unspecified => Unspecified,
+            proto::AggregationTemporality::Delta => Delta,
+            proto::AggregationTemporality::Cumulative => Cumulative,
+        }
+    }
+}
+
+/// View for Histogram
+pub trait HistogramView {
+    /// The `HistogramDataPointView` type associated with this implementation.
+    type HistogramDataPoint<'dp>: HistogramDataPointView
+    where
+        Self: 'dp;
+
+    /// Iterator type yielding HistogramDataPoints.
+    type HistogramDataPointIter<'dp>: Iterator<Item = Self::HistogramDataPoint<'dp>>
+    where
+        Self: 'dp;
+
+    /// Access the Histogram's data points
+    fn data_points(&self) -> Self::HistogramDataPointIter<'_>;
+
+    /// Access the Histogram's aggregation temporality
+    fn aggregation_temporality(&self) -> AggregationTemporality;
+}
+
+/// View for HistogramDataPoint
+pub trait HistogramDataPointView {
+    /// The `AttributeView` type associated with this implementation.
+    type Attribute<'att>: AttributeView
+    where
+        Self: 'att;
+
+    /// Iterator type for yielding attributes.
+    type AttributeIter<'att>: Iterator<Item = Self::Attribute<'att>>
+    where
+        Self: 'att;
+
+    /// Iterator type for yielding bucket counts.
+    type BucketCountIter<'bc>: Iterator<Item = &'bc u64>
+    where
+        Self: 'bc;
+
+    /// Iterator type for yielding explicit bounds.
+    type ExplicitBoundsIter<'eb>: Iterator<Item = &'eb f64>
+    where
+        Self: 'eb;
+
+    /// The `ExemplarView` type associated with this implementation.
+    type Exemplar<'ex>: ExemplarView
+    where
+        Self: 'ex;
+
+    /// Iteratory type for yielding Exemplar wrappers.
+    type ExemplarIter<'ex>: Iterator<Item = Self::Exemplar<'ex>>
+    where
+        Self: 'ex;
+
+    /// Get the attributes
+    fn attributes(&self) -> Self::AttributeIter<'_>;
+
+    /// Access the start time
+    fn start_time_unix_nano(&self) -> u64;
+
+    /// Access the time
+    fn time_unix_nano(&self) -> u64;
+
+    /// Get the count
+    fn count(&self) -> u64;
+
+    /// Get the sum
+    fn sum(&self) -> Option<f64>;
+
+    /// Get the count values of the histogram for each bucket
+    fn bucket_counts(&self) -> Self::BucketCountIter<'_>;
+
+    /// Get buckets with explicitly defined bounds for values
+    fn explicit_bounds(&self) -> Self::ExplicitBoundsIter<'_>;
+
+    /// Access the point's exemplars
+    fn exemplars(&self) -> Self::ExemplarIter<'_>;
+
+    /// Get the flags
+    fn flags(&self) -> DataPointFlags;
+
+    /// Get the minimum value over (start_time, end_time)
+    fn min(&self) -> Option<f64>;
+
+    /// Get the maximum value over (start_time, end_time)
+    fn max(&self) -> Option<f64>;
+}
+
+/// View for ExponentialHistogram
+pub trait ExponentialHistogramView {
+    /// The `ExponentialHistogramDataPointView` type associated with this implementation.
+    type ExponentialHistogramDataPoint<'edp>: ExponentialHistogramDataPointView
+    where
+        Self: 'edp;
+
+    /// Iterator type for yielding data points.
+    type ExponentialHistogramDataPointIter<'edp>: Iterator<
+        Item = Self::ExponentialHistogramDataPoint<'edp>,
+    >
+    where
+        Self: 'edp;
+
+    /// Access the Histogram's data points
+    fn data_points(&self) -> Self::ExponentialHistogramDataPointIter<'_>;
+
+    /// Access the Histogram's aggregation temporality
+    fn aggregation_temporality(&self) -> AggregationTemporality;
+}
+
+/// View for ExponentialHistogramDataPoint
+pub trait ExponentialHistogramDataPointView {
+    /// The `AttributeView` type associated with this implementation.
+    type Attribute<'att>: AttributeView
+    where
+        Self: 'att;
+
+    /// Iterator type for yielding attributes.
+    type AttributeIter<'att>: Iterator<Item = Self::Attribute<'att>>
+    where
+        Self: 'att;
+
+    /// The `BucketsView` type associated with this implementation.
+    type Buckets<'b>: BucketsView
+    where
+        Self: 'b;
+
+    /// The `ExemplarView` type associated with this implementation.
+    type Exemplar<'ex>: ExemplarView
+    where
+        Self: 'ex;
+
+    /// Iteratory type for yielding Exemplar wrappers.
+    type ExemplarIter<'ex>: Iterator<Item = Self::Exemplar<'ex>>
+    where
+        Self: 'ex;
+
+    /// Get the attributes
+    fn attributes(&self) -> Self::AttributeIter<'_>;
+
+    /// Access the start time
+    fn start_time_unix_nano(&self) -> u64;
+
+    /// Access the time
+    fn time_unix_nano(&self) -> u64;
+
+    /// Get the count
+    fn count(&self) -> u64;
+
+    /// Get the sum
+    fn sum(&self) -> Option<f64>;
+
+    /// Get the histogram resolution
+    fn scale(&self) -> i32;
+
+    /// Get the count of values that are either exactly zero of within the region considered zero by
+    /// the instrumentation.
+    fn zero_count(&self) -> u64;
+
+    /// Get the positive range of exponential bucket counts.
+    fn positive(&self) -> Option<Self::Buckets<'_>>;
+
+    /// Get the negative range of exponential bucket counts.
+    fn negative(&self) -> Option<Self::Buckets<'_>>;
+
+    /// Get the flags
+    fn flags(&self) -> DataPointFlags;
+
+    /// Access the point's exemplars
+    fn exemplars(&self) -> Self::ExemplarIter<'_>;
+
+    /// Get the minimum value over (start_time, end_time)
+    fn min(&self) -> Option<f64>;
+
+    /// Get the maximum value over (start_time, end_time)
+    fn max(&self) -> Option<f64>;
+
+    /// Get the ZeroThreshold
+    fn zero_threshold(&self) -> f64;
+}
+
+/// View for Bucket
+pub trait BucketsView {
+    /// Iterator type for bucket counts.
+    type BucketCountIter<'bc>: Iterator<Item = &'bc u64>
+    where
+        Self: 'bc;
+
+    /// Get the bucket index of the first entry in the array.
+    fn offset(&self) -> i32;
+
+    /// Get the array of bucket counts.
+    fn bucket_counts(&self) -> Self::BucketCountIter<'_>;
+}

--- a/rust/otel-arrow-rust/src/encode/record.rs
+++ b/rust/otel-arrow-rust/src/encode/record.rs
@@ -5,6 +5,7 @@
 
 pub mod attributes;
 pub mod logs;
+pub mod metrics;
 pub mod spans;
 
 mod array;

--- a/rust/otel-arrow-rust/src/encode/record/metrics.rs
+++ b/rust/otel-arrow-rust/src/encode/record/metrics.rs
@@ -952,15 +952,13 @@ impl HistogramDataPointsRecordBatchBuilder {
     }
 
     /// Append a value to the `bucket_counts` array.
-    pub fn append_bucket_counts(&mut self, val: &[u64]) {
-        self.bucket_counts
-            .append_value(val.iter().copied().map(Some))
+    pub fn append_bucket_counts(&mut self, val: impl Iterator<Item = u64>) {
+        self.bucket_counts.append_value(val.map(Some))
     }
 
     /// Append a value to the `explicit_bounds` array.
-    pub fn append_explicit_bounds(&mut self, val: &[f64]) {
-        self.explicit_bounds
-            .append_value(val.iter().copied().map(Some))
+    pub fn append_explicit_bounds(&mut self, val: impl Iterator<Item = f64>) {
+        self.explicit_bounds.append_value(val.map(Some))
     }
 
     /// Append a value to the `sum` array.
@@ -1407,12 +1405,11 @@ impl BucketsRecordBatchBuilder {
     }
 
     /// Append a new value.
-    pub fn append(&mut self, val: Option<(i32, &[u64])>) {
+    pub fn append(&mut self, val: Option<(i32, impl Iterator<Item = u64>)>) {
         match val {
             Some((offset, bucket_counts)) => {
                 self.offset.append_value(&offset);
-                self.bucket_counts
-                    .append_value(bucket_counts.iter().copied().map(Some));
+                self.bucket_counts.append_value(bucket_counts.map(Some));
                 self.nulls.append_non_null();
             }
             None => {

--- a/rust/otel-arrow-rust/src/encode/record/metrics.rs
+++ b/rust/otel-arrow-rust/src/encode/record/metrics.rs
@@ -1,0 +1,1455 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains builders for record batches for metrics.
+
+use std::sync::Arc;
+
+use arrow::{
+    array::{
+        Array, LargeListBuilder, NullBufferBuilder, PrimitiveBuilder, RecordBatch, StructArray,
+    },
+    datatypes::{Field, Fields, Float64Type, Schema, UInt64Type},
+    error::ArrowError,
+};
+
+use crate::{
+    encode::record::{
+        array::{
+            ArrayAppend, ArrayAppendNulls, ArrayAppendStr, ArrayOptions, CheckedArrayAppendSlice,
+            FixedSizeBinaryArrayBuilder, Float64ArrayBuilder, Int32ArrayBuilder, Int64ArrayBuilder,
+            StringArrayBuilder, TimestampNanosecondArrayBuilder, UInt16ArrayBuilder,
+            UInt32ArrayBuilder, UInt64ArrayBuilder, dictionary::DictionaryOptions,
+        },
+        logs::{ResourceBuilder, ScopeBuilder},
+    },
+    schema::consts,
+};
+
+use super::array::{
+    UInt8ArrayBuilder,
+    boolean::{AdaptiveBooleanArrayBuilder, BooleanBuilderOptions},
+};
+
+// These are copied from `pdata-views::views::common` because they're simple and I don't want to
+// introduce a cross-cutting dependency.
+
+/// Trace IDs are 16 binary bytes.
+pub type TraceId = [u8; 16];
+
+/// Span IDs are 8 binary bytes.
+pub type SpanId = [u8; 8];
+
+/// Record batch builder for metrics
+pub struct MetricsRecordBatchBuilder {
+    id: UInt16ArrayBuilder,
+
+    /// the builder for the resource struct for this metric record batch
+    pub resource: ResourceBuilder,
+
+    /// the builder for the scope struct for this metric record batch
+    pub scope: ScopeBuilder,
+
+    scope_schema_url: StringArrayBuilder,
+    metric_type: UInt8ArrayBuilder,
+    name: StringArrayBuilder,
+    description: StringArrayBuilder,
+    unit: StringArrayBuilder,
+    aggregation_temporality: Int32ArrayBuilder,
+    is_monotonic: AdaptiveBooleanArrayBuilder,
+}
+
+impl Default for MetricsRecordBatchBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MetricsRecordBatchBuilder {
+    /// Create a new instance of `Metrics`
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            id: UInt16ArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            resource: ResourceBuilder::new(),
+            scope: ScopeBuilder::new(),
+            scope_schema_url: StringArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: Some(DictionaryOptions::dict8()),
+                ..Default::default()
+            }),
+            metric_type: UInt8ArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            name: StringArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: Some(DictionaryOptions::dict8()),
+                ..Default::default()
+            }),
+            description: StringArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: Some(DictionaryOptions::dict8()),
+                ..Default::default()
+            }),
+            unit: StringArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: Some(DictionaryOptions::dict8()),
+                ..Default::default()
+            }),
+            aggregation_temporality: Int32ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: Some(DictionaryOptions::dict8()),
+                ..Default::default()
+            }),
+            is_monotonic: AdaptiveBooleanArrayBuilder::new(BooleanBuilderOptions {
+                optional: true,
+            }),
+        }
+    }
+
+    /// Append a value to the `id` array.
+    pub fn append_id(&mut self, val: u16) {
+        self.id.append_value(&val);
+    }
+
+    /// Append a value to the `scope_schema_url` array.
+    pub fn append_scope_schema_url(&mut self, val: &str) {
+        self.scope_schema_url.append_str(val);
+    }
+
+    /// Append a value to the `metric_type` array.
+    pub fn append_metric_type(&mut self, val: u8) {
+        self.metric_type.append_value(&val);
+    }
+
+    /// Append a value to the `name` array.
+    pub fn append_name(&mut self, val: &str) {
+        self.name.append_str(val);
+    }
+
+    /// Append a value to the `description` array.
+    pub fn append_description(&mut self, val: &str) {
+        self.description.append_str(val);
+    }
+
+    /// Append a value to the `unit` array.
+    pub fn append_unit(&mut self, val: &str) {
+        self.unit.append_str(val);
+    }
+
+    /// Append a value to the `aggregation_temporality` array.
+    pub fn append_aggregation_temporality(&mut self, val: Option<i32>) {
+        match val {
+            Some(val) => self.aggregation_temporality.append_value(&val),
+            None => self.aggregation_temporality.append_null(),
+        }
+    }
+
+    /// Append a value to the `is_monotonic` array.
+    pub fn append_is_monotonic(&mut self, val: Option<bool>) {
+        match val {
+            Some(val) => self.is_monotonic.append_value(val),
+            None => self.is_monotonic.append_null(),
+        }
+    }
+
+    /// Construct an OTAP Metrics RecordBatch from the builders.
+    pub fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        let mut fields = Vec::with_capacity(8);
+        let mut columns = Vec::with_capacity(8);
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self.id.finish().expect("finish returns `Some(array)`");
+        fields.push(Field::new(consts::ID, array.data_type().clone(), false));
+        columns.push(array);
+
+        let resource = self.resource.finish()?;
+        if !resource.is_empty() {
+            fields.push(Field::new(
+                consts::RESOURCE,
+                resource.data_type().clone(),
+                true,
+            ));
+            columns.push(Arc::new(resource));
+        }
+
+        let scope = self.scope.finish()?;
+        if !scope.is_empty() {
+            fields.push(Field::new(consts::SCOPE, scope.data_type().clone(), true));
+            columns.push(Arc::new(scope));
+        }
+
+        if let Some(array) = self.scope_schema_url.finish() {
+            fields.push(Field::new(
+                consts::SCHEMA_URL,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self
+            .metric_type
+            .finish()
+            .expect("finish returns `Some(array)`");
+        fields.push(Field::new(
+            consts::METRIC_TYPE,
+            array.data_type().clone(),
+            false,
+        ));
+        columns.push(array);
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self.name.finish().expect("finish returns `Some(array)`");
+        fields.push(Field::new(consts::NAME, array.data_type().clone(), false));
+        columns.push(array);
+
+        if let Some(array) = self.description.finish() {
+            fields.push(Field::new(
+                consts::DESCRIPTION,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.unit.finish() {
+            fields.push(Field::new(consts::UNIT, array.data_type().clone(), false));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.aggregation_temporality.finish() {
+            fields.push(Field::new(
+                consts::AGGREGATION_TEMPORALITY,
+                array.data_type().clone(),
+                true,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.is_monotonic.finish() {
+            fields.push(Field::new(
+                consts::IS_MONOTONIC,
+                array.data_type().clone(),
+                true,
+            ));
+            columns.push(array);
+        }
+
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+    }
+}
+
+/// Record batch builder for numberdatapoints
+pub struct NumberDataPointsRecordBatchBuilder {
+    id: UInt32ArrayBuilder,
+    parent_id: UInt16ArrayBuilder,
+    start_time_unix_nano: TimestampNanosecondArrayBuilder,
+    time_unix_nano: TimestampNanosecondArrayBuilder,
+    int_value: Int64ArrayBuilder,
+    double_value: Float64ArrayBuilder,
+    flags: UInt32ArrayBuilder,
+}
+
+impl NumberDataPointsRecordBatchBuilder {
+    /// Create a new instance of `NumberDataPoints`
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            id: UInt32ArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            parent_id: UInt16ArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            start_time_unix_nano: TimestampNanosecondArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            time_unix_nano: TimestampNanosecondArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            int_value: Int64ArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            double_value: Float64ArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            flags: UInt32ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+        }
+    }
+
+    /// Append a value to the `id` array.
+    pub fn append_id(&mut self, val: u32) {
+        self.id.append_value(&val);
+    }
+
+    /// Append a value to the `parent_id` array.
+    pub fn append_parent_id(&mut self, val: u16) {
+        self.parent_id.append_value(&val);
+    }
+
+    /// Append a value to the `start_time_unix_nano` array.
+    pub fn append_start_time_unix_nano(&mut self, val: Option<i64>) {
+        match val {
+            Some(val) => self.start_time_unix_nano.append_value(&val),
+            None => self.start_time_unix_nano.append_null(),
+        }
+    }
+
+    /// Append a value to the `time_unix_nano` array.
+    pub fn append_time_unix_nano(&mut self, val: i64) {
+        self.time_unix_nano.append_value(&val);
+    }
+
+    /// Append a value to the `int_value` array.
+    pub fn append_int_value(&mut self, val: Option<i64>) {
+        match val {
+            Some(val) => self.int_value.append_value(&val),
+            None => self.int_value.append_null(),
+        }
+    }
+
+    /// Append a value to the `double_value` array.
+    pub fn append_double_value(&mut self, val: Option<f64>) {
+        match val {
+            Some(val) => self.double_value.append_value(&val),
+            None => self.double_value.append_null(),
+        }
+    }
+
+    /// Append a value to the `flags` array.
+    pub fn append_flags(&mut self, val: u32) {
+        self.flags.append_value(&val);
+    }
+
+    /// Construct an OTAP NumberDataPoints RecordBatch from the builders.
+    pub fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        let mut fields = Vec::with_capacity(7);
+        let mut columns = Vec::with_capacity(7);
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self.id.finish().expect("finish returns `Some(array)`");
+        fields.push(Field::new(consts::ID, array.data_type().clone(), false));
+        columns.push(array);
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self
+            .parent_id
+            .finish()
+            .expect("finish returns `Some(array)`");
+        fields.push(Field::new(
+            consts::PARENT_ID,
+            array.data_type().clone(),
+            false,
+        ));
+        columns.push(array);
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self
+            .start_time_unix_nano
+            .finish()
+            .expect("finish returns `Some(array)`");
+        fields.push(Field::new(
+            consts::START_TIME_UNIX_NANO,
+            array.data_type().clone(),
+            true,
+        ));
+        columns.push(array);
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self
+            .time_unix_nano
+            .finish()
+            .expect("finish returns `Some(array)`");
+        fields.push(Field::new(
+            consts::TIME_UNIX_NANO,
+            array.data_type().clone(),
+            false,
+        ));
+        columns.push(array);
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self
+            .int_value
+            .finish()
+            .expect("finish returns `Some(array)`");
+        fields.push(Field::new(
+            consts::INT_VALUE,
+            array.data_type().clone(),
+            true,
+        ));
+        columns.push(array);
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self
+            .double_value
+            .finish()
+            .expect("finish returns `Some(array)`");
+        fields.push(Field::new(
+            consts::DOUBLE_VALUE,
+            array.data_type().clone(),
+            true,
+        ));
+        columns.push(array);
+
+        if let Some(array) = self.flags.finish() {
+            fields.push(Field::new(consts::FLAGS, array.data_type().clone(), false));
+            columns.push(array);
+        }
+
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+    }
+}
+
+/// Record batch builder for exemplars
+pub struct ExemplarsRecordBatchBuilder {
+    id: UInt32ArrayBuilder,
+    parent_id: UInt32ArrayBuilder,
+    time_unix_nano: TimestampNanosecondArrayBuilder,
+    int_value: Int64ArrayBuilder,
+    double_value: Float64ArrayBuilder,
+    span_id: FixedSizeBinaryArrayBuilder,
+    trace_id: FixedSizeBinaryArrayBuilder,
+}
+
+impl Default for ExemplarsRecordBatchBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExemplarsRecordBatchBuilder {
+    /// Create a new instance of `Exemplars`
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            id: UInt32ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            parent_id: UInt32ArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            time_unix_nano: TimestampNanosecondArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            int_value: Int64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            double_value: Float64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            span_id: FixedSizeBinaryArrayBuilder::new_with_args(
+                ArrayOptions {
+                    optional: true,
+                    dictionary_options: Some(DictionaryOptions::dict8()),
+                    ..Default::default()
+                },
+                16,
+            ),
+            trace_id: FixedSizeBinaryArrayBuilder::new_with_args(
+                ArrayOptions {
+                    optional: true,
+                    dictionary_options: Some(DictionaryOptions::dict8()),
+                    ..Default::default()
+                },
+                8,
+            ),
+        }
+    }
+
+    /// Append a value to the `id` array.
+    pub fn append_id(&mut self, val: u32) {
+        self.id.append_value(&val);
+    }
+
+    /// Append a value to the `parent_id` array.
+    pub fn append_parent_id(&mut self, val: u32) {
+        self.parent_id.append_value(&val);
+    }
+
+    /// Append a value to the `time_unix_nano` array.
+    pub fn append_time_unix_nano(&mut self, val: i64) {
+        self.time_unix_nano.append_value(&val);
+    }
+
+    /// Append a value to the `int_value` array.
+    pub fn append_int_value(&mut self, val: i64) {
+        self.int_value.append_value(&val);
+    }
+
+    /// Append a value to the `double_value` array.
+    pub fn append_double_value(&mut self, val: f64) {
+        self.double_value.append_value(&val);
+    }
+
+    /// Append a value to the `span_id` array.
+    pub fn append_span_id(&mut self, val: &SpanId) -> Result<(), ArrowError> {
+        self.span_id.append_slice(val)
+    }
+
+    /// Append a value to the `trace_id` array.
+    pub fn append_trace_id(&mut self, val: &TraceId) -> Result<(), ArrowError> {
+        self.trace_id.append_slice(val)
+    }
+
+    /// Construct an OTAP Exemplars RecordBatch from the builders.
+    pub fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        let mut fields = Vec::with_capacity(7);
+        let mut columns = Vec::with_capacity(7);
+
+        if let Some(array) = self.id.finish() {
+            fields.push(Field::new(consts::ID, array.data_type().clone(), false));
+            columns.push(array);
+        }
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self
+            .parent_id
+            .finish()
+            .expect("finish returns `Some(array)`");
+        fields.push(Field::new(
+            consts::PARENT_ID,
+            array.data_type().clone(),
+            false,
+        ));
+        columns.push(array);
+
+        if let Some(array) = self.time_unix_nano.finish() {
+            fields.push(Field::new(
+                consts::TIME_UNIX_NANO,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.int_value.finish() {
+            fields.push(Field::new(
+                consts::INT_VALUE,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.double_value.finish() {
+            fields.push(Field::new(
+                consts::DOUBLE_VALUE,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.span_id.finish() {
+            fields.push(Field::new(
+                consts::SPAN_ID,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.trace_id.finish() {
+            fields.push(Field::new(
+                consts::TRACE_ID,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+    }
+}
+
+/// Record batch builder for quantile
+pub struct QuantileRecordBatchBuilder {
+    quantile: Float64ArrayBuilder,
+    value: Float64ArrayBuilder,
+}
+
+impl Default for QuantileRecordBatchBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl QuantileRecordBatchBuilder {
+    /// Create a new instance of `Quantile`
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            quantile: Float64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            value: Float64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+        }
+    }
+
+    /// Append a value to the `quantile` array.
+    pub fn append_quantile(&mut self, val: f64) {
+        self.quantile.append_value(&val);
+    }
+
+    /// Append a value to the `value` array.
+    pub fn append_value(&mut self, val: f64) {
+        self.value.append_value(&val);
+    }
+
+    /// Construct an OTAP Quantile RecordBatch from the builders.
+    pub fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        let mut fields = Vec::with_capacity(2);
+        let mut columns = Vec::with_capacity(2);
+
+        if let Some(array) = self.quantile.finish() {
+            fields.push(Field::new(
+                consts::SUMMARY_QUANTILE,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.value.finish() {
+            fields.push(Field::new(
+                consts::SUMMARY_VALUE,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+    }
+}
+
+/// Record batch builder for summarydatapoints
+pub struct SummaryDataPointsRecordBatchBuilder {
+    id: UInt32ArrayBuilder,
+    parent_id: UInt16ArrayBuilder,
+    start_time_unix_nano: TimestampNanosecondArrayBuilder,
+    time_unix_nano: TimestampNanosecondArrayBuilder,
+    count: UInt64ArrayBuilder,
+    sum: Float64ArrayBuilder,
+
+    /// the builder for quantile-value pairs
+    pub quantile_values: QuantileRecordBatchBuilder,
+    flags: UInt32ArrayBuilder,
+}
+
+impl Default for SummaryDataPointsRecordBatchBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SummaryDataPointsRecordBatchBuilder {
+    /// Create a new instance of `SummaryDataPoints`
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            id: UInt32ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            parent_id: UInt16ArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            start_time_unix_nano: TimestampNanosecondArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            time_unix_nano: TimestampNanosecondArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            count: UInt64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            sum: Float64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            quantile_values: QuantileRecordBatchBuilder::new(),
+            flags: UInt32ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+        }
+    }
+
+    /// Append a value to the `id` array.
+    pub fn append_id(&mut self, val: u32) {
+        self.id.append_value(&val);
+    }
+
+    /// Append a value to the `parent_id` array.
+    pub fn append_parent_id(&mut self, val: u16) {
+        self.parent_id.append_value(&val);
+    }
+
+    /// Append a value to the `start_time_unix_nano` array.
+    pub fn append_start_time_unix_nano(&mut self, val: i64) {
+        self.start_time_unix_nano.append_value(&val);
+    }
+
+    /// Append a value to the `time_unix_nano` array.
+    pub fn append_time_unix_nano(&mut self, val: i64) {
+        self.time_unix_nano.append_value(&val);
+    }
+
+    /// Append a value to the `count` array.
+    pub fn append_count(&mut self, val: u64) {
+        self.count.append_value(&val);
+    }
+
+    /// Append a value to the `sum` array.
+    pub fn append_sum(&mut self, val: f64) {
+        self.sum.append_value(&val);
+    }
+
+    /// Append a value to the `flags` array.
+    pub fn append_flags(&mut self, val: u32) {
+        self.flags.append_value(&val);
+    }
+
+    /// Construct an OTAP SummaryDataPoints RecordBatch from the builders.
+    pub fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        let mut fields = Vec::with_capacity(7);
+        let mut columns = Vec::with_capacity(7);
+
+        if let Some(array) = self.id.finish() {
+            fields.push(Field::new(consts::ID, array.data_type().clone(), false));
+            columns.push(array);
+        }
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self
+            .parent_id
+            .finish()
+            .expect("finish returns `Some(array)`");
+        fields.push(Field::new(
+            consts::PARENT_ID,
+            array.data_type().clone(),
+            false,
+        ));
+        columns.push(array);
+
+        if let Some(array) = self.start_time_unix_nano.finish() {
+            fields.push(Field::new(
+                consts::START_TIME_UNIX_NANO,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.time_unix_nano.finish() {
+            fields.push(Field::new(
+                consts::TIME_UNIX_NANO,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.count.finish() {
+            fields.push(Field::new(
+                consts::SUMMARY_COUNT,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.sum.finish() {
+            fields.push(Field::new(
+                consts::SUMMARY_SUM,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        let array: StructArray = self.quantile_values.finish()?.into();
+        if !array.is_empty() {
+            fields.push(Field::new(
+                consts::SUMMARY_QUANTILE_VALUES,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(Arc::new(array));
+        }
+
+        if let Some(array) = self.flags.finish() {
+            fields.push(Field::new(consts::FLAGS, array.data_type().clone(), false));
+            columns.push(array);
+        }
+
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+    }
+}
+
+/// Record batch builder for histogramdatapoints
+pub struct HistogramDataPointsRecordBatchBuilder {
+    id: UInt32ArrayBuilder,
+    parent_id: UInt16ArrayBuilder,
+    start_time_unix_nano: TimestampNanosecondArrayBuilder,
+    time_unix_nano: TimestampNanosecondArrayBuilder,
+    count: UInt64ArrayBuilder,
+    bucket_counts: LargeListBuilder<PrimitiveBuilder<UInt64Type>>,
+    explicit_bounds: LargeListBuilder<PrimitiveBuilder<Float64Type>>,
+    sum: Float64ArrayBuilder,
+    flags: UInt32ArrayBuilder,
+    min: Float64ArrayBuilder,
+    max: Float64ArrayBuilder,
+}
+
+impl Default for HistogramDataPointsRecordBatchBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HistogramDataPointsRecordBatchBuilder {
+    /// Create a new instance of `HistogramDataPoints`
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            id: UInt32ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            parent_id: UInt16ArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            start_time_unix_nano: TimestampNanosecondArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            time_unix_nano: TimestampNanosecondArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            count: UInt64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            bucket_counts: LargeListBuilder::new(PrimitiveBuilder::new()),
+            explicit_bounds: LargeListBuilder::new(PrimitiveBuilder::new()),
+            sum: Float64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            flags: UInt32ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            min: Float64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            max: Float64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+        }
+    }
+
+    /// Append a value to the `id` array.
+    pub fn append_id(&mut self, val: u32) {
+        self.id.append_value(&val);
+    }
+
+    /// Append a value to the `parent_id` array.
+    pub fn append_parent_id(&mut self, val: u16) {
+        self.parent_id.append_value(&val);
+    }
+
+    /// Append a value to the `start_time_unix_nano` array.
+    pub fn append_start_time_unix_nano(&mut self, val: i64) {
+        self.start_time_unix_nano.append_value(&val);
+    }
+
+    /// Append a value to the `time_unix_nano` array.
+    pub fn append_time_unix_nano(&mut self, val: i64) {
+        self.time_unix_nano.append_value(&val);
+    }
+
+    /// Append a value to the `count` array.
+    pub fn append_count(&mut self, val: u64) {
+        self.count.append_value(&val);
+    }
+
+    /// Append a value to the `bucket_counts` array.
+    pub fn append_bucket_counts(&mut self, val: &[u64]) {
+        self.bucket_counts
+            .append_value(val.iter().copied().map(Some))
+    }
+
+    /// Append a value to the `explicit_bounds` array.
+    pub fn append_explicit_bounds(&mut self, val: &[f64]) {
+        self.explicit_bounds
+            .append_value(val.iter().copied().map(Some))
+    }
+
+    /// Append a value to the `sum` array.
+    pub fn append_sum(&mut self, val: Option<f64>) {
+        match val {
+            Some(val) => self.sum.append_value(&val),
+            None => self.sum.append_null(),
+        }
+    }
+
+    /// Append a value to the `flags` array.
+    pub fn append_flags(&mut self, val: u32) {
+        self.flags.append_value(&val);
+    }
+
+    /// Append a value to the `min` array.
+    pub fn append_min(&mut self, val: Option<f64>) {
+        match val {
+            Some(val) => self.min.append_value(&val),
+            None => self.min.append_null(),
+        }
+    }
+
+    /// Append a value to the `max` array.
+    pub fn append_max(&mut self, val: Option<f64>) {
+        match val {
+            Some(val) => self.max.append_value(&val),
+            None => self.max.append_null(),
+        }
+    }
+
+    /// Construct an OTAP HistogramDataPoints RecordBatch from the builders.
+    pub fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        let mut fields = Vec::with_capacity(11);
+        let mut columns = Vec::with_capacity(11);
+
+        if let Some(array) = self.id.finish() {
+            fields.push(Field::new(consts::ID, array.data_type().clone(), false));
+            columns.push(array);
+        }
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self
+            .parent_id
+            .finish()
+            .expect("finish returns `Some(array)`");
+        fields.push(Field::new(
+            consts::PARENT_ID,
+            array.data_type().clone(),
+            false,
+        ));
+        columns.push(array);
+
+        if let Some(array) = self.start_time_unix_nano.finish() {
+            fields.push(Field::new(
+                consts::START_TIME_UNIX_NANO,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.time_unix_nano.finish() {
+            fields.push(Field::new(
+                consts::TIME_UNIX_NANO,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.count.finish() {
+            fields.push(Field::new(
+                consts::HISTOGRAM_COUNT,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        let array = self.bucket_counts.finish();
+        if !array.is_empty() {
+            fields.push(Field::new(
+                consts::HISTOGRAM_BUCKET_COUNTS,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(Arc::new(array));
+        }
+
+        let array = self.explicit_bounds.finish();
+        if !array.is_empty() {
+            fields.push(Field::new(
+                consts::HISTOGRAM_EXPLICIT_BOUNDS,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(Arc::new(array));
+        }
+
+        if let Some(array) = self.sum.finish() {
+            fields.push(Field::new(
+                consts::HISTOGRAM_SUM,
+                array.data_type().clone(),
+                true,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.flags.finish() {
+            fields.push(Field::new(consts::FLAGS, array.data_type().clone(), false));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.min.finish() {
+            fields.push(Field::new(
+                consts::HISTOGRAM_MIN,
+                array.data_type().clone(),
+                true,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.max.finish() {
+            fields.push(Field::new(
+                consts::HISTOGRAM_MAX,
+                array.data_type().clone(),
+                true,
+            ));
+            columns.push(array);
+        }
+
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+    }
+}
+
+/// Record batch builder for exponentialhistogramdatapoints
+pub struct ExponentialHistogramDataPointsRecordBatchBuilder {
+    id: UInt32ArrayBuilder,
+    parent_id: UInt16ArrayBuilder,
+    start_time_unix_nano: TimestampNanosecondArrayBuilder,
+    time_unix_nano: TimestampNanosecondArrayBuilder,
+    count: UInt64ArrayBuilder,
+    sum: Float64ArrayBuilder,
+    scale: Int32ArrayBuilder,
+    zero_count: UInt64ArrayBuilder,
+    /// The builder for positive buckets.
+    pub positive: BucketsRecordBatchBuilder,
+    /// The builder for negative buckets.
+    pub negative: BucketsRecordBatchBuilder,
+    flags: UInt32ArrayBuilder,
+    min: Float64ArrayBuilder,
+    max: Float64ArrayBuilder,
+}
+
+impl Default for ExponentialHistogramDataPointsRecordBatchBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExponentialHistogramDataPointsRecordBatchBuilder {
+    /// Create a new instance of `ExponentialHistogramDataPoints`
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            id: UInt32ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            parent_id: UInt16ArrayBuilder::new(ArrayOptions {
+                optional: false,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            start_time_unix_nano: TimestampNanosecondArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            time_unix_nano: TimestampNanosecondArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            count: UInt64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            sum: Float64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            scale: Int32ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            zero_count: UInt64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            positive: BucketsRecordBatchBuilder::new(),
+            negative: BucketsRecordBatchBuilder::new(),
+            flags: UInt32ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            min: Float64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            max: Float64ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+        }
+    }
+
+    /// Append a value to the `id` array.
+    pub fn append_id(&mut self, val: u32) {
+        self.id.append_value(&val);
+    }
+
+    /// Append a value to the `parent_id` array.
+    pub fn append_parent_id(&mut self, val: u16) {
+        self.parent_id.append_value(&val);
+    }
+
+    /// Append a value to the `start_time_unix_nano` array.
+    pub fn append_start_time_unix_nano(&mut self, val: i64) {
+        self.start_time_unix_nano.append_value(&val);
+    }
+
+    /// Append a value to the `time_unix_nano` array.
+    pub fn append_time_unix_nano(&mut self, val: i64) {
+        self.time_unix_nano.append_value(&val);
+    }
+
+    /// Append a value to the `count` array.
+    pub fn append_count(&mut self, val: u64) {
+        self.count.append_value(&val);
+    }
+
+    /// Append a value to the `sum` array.
+    pub fn append_sum(&mut self, val: Option<f64>) {
+        match val {
+            Some(val) => self.sum.append_value(&val),
+            None => self.sum.append_null(),
+        }
+    }
+
+    /// Append a value to the `scale` array.
+    pub fn append_scale(&mut self, val: i32) {
+        self.scale.append_value(&val);
+    }
+
+    /// Append a value to the `zero_count` array.
+    pub fn append_zero_count(&mut self, val: u64) {
+        self.zero_count.append_value(&val);
+    }
+
+    /// Append a value to the `flags` array.
+    pub fn append_flags(&mut self, val: u32) {
+        self.flags.append_value(&val);
+    }
+
+    /// Append a value to the `min` array.
+    pub fn append_min(&mut self, val: Option<f64>) {
+        match val {
+            Some(val) => self.min.append_value(&val),
+            None => self.min.append_null(),
+        }
+    }
+
+    /// Append a value to the `max` array.
+    pub fn append_max(&mut self, val: Option<f64>) {
+        match val {
+            Some(val) => self.max.append_value(&val),
+            None => self.max.append_null(),
+        }
+    }
+
+    /// Construct an OTAP ExponentialHistogramDataPoints RecordBatch from the builders.
+    pub fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        let mut fields = Vec::with_capacity(11);
+        let mut columns = Vec::with_capacity(11);
+
+        if let Some(array) = self.id.finish() {
+            fields.push(Field::new(consts::ID, array.data_type().clone(), false));
+            columns.push(array);
+        }
+
+        // SAFETY: `expect` is safe here because `AdaptiveArrayBuilder` guarantees that for
+        // non-optional arrays, `finish()` will always return an array, even if it is empty.
+        let array = self
+            .parent_id
+            .finish()
+            .expect("finish returns `Some(array)`");
+        fields.push(Field::new(
+            consts::PARENT_ID,
+            array.data_type().clone(),
+            false,
+        ));
+        columns.push(array);
+
+        if let Some(array) = self.start_time_unix_nano.finish() {
+            fields.push(Field::new(
+                consts::START_TIME_UNIX_NANO,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.time_unix_nano.finish() {
+            fields.push(Field::new(
+                consts::TIME_UNIX_NANO,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.count.finish() {
+            fields.push(Field::new(
+                consts::HISTOGRAM_COUNT,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.sum.finish() {
+            fields.push(Field::new(
+                consts::HISTOGRAM_SUM,
+                array.data_type().clone(),
+                true,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.scale.finish() {
+            fields.push(Field::new(
+                consts::EXP_HISTOGRAM_SCALE,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.zero_count.finish() {
+            fields.push(Field::new(
+                consts::EXP_HISTOGRAM_ZERO_COUNT,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        let array: StructArray = self.positive.finish()?;
+        if !array.is_empty() {
+            fields.push(Field::new(
+                consts::EXP_HISTOGRAM_POSITIVE,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(Arc::new(array));
+        }
+
+        let array: StructArray = self.negative.finish()?;
+        if !array.is_empty() {
+            fields.push(Field::new(
+                consts::EXP_HISTOGRAM_NEGATIVE,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(Arc::new(array));
+        }
+
+        if let Some(array) = self.flags.finish() {
+            fields.push(Field::new(consts::FLAGS, array.data_type().clone(), false));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.min.finish() {
+            fields.push(Field::new(
+                consts::HISTOGRAM_MIN,
+                array.data_type().clone(),
+                true,
+            ));
+            columns.push(array);
+        }
+
+        if let Some(array) = self.max.finish() {
+            fields.push(Field::new(
+                consts::HISTOGRAM_MAX,
+                array.data_type().clone(),
+                true,
+            ));
+            columns.push(array);
+        }
+
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+    }
+}
+
+/// Record batch builder for ExponentialHistogram Buckets.
+// This builder is a bit different because we build a `StructArray` directly rather than converting
+// from a `RecordBatch`; we do that because `offset` and `bucket_counts` are supposed to be
+// non-nullable and we represent missing data with null entries in the `StructArray` and
+// `RecordBatch` can't represent top-level nulls.
+pub struct BucketsRecordBatchBuilder {
+    offset: Int32ArrayBuilder,
+    bucket_counts: LargeListBuilder<PrimitiveBuilder<UInt64Type>>,
+    nulls: NullBufferBuilder,
+}
+
+/// `NullBufferBuilder` will only allocate when it sees a `false` value and when it allocates, it
+/// will initially allocate this many bits. Make sure this value is a multiple of 64.
+const NULL_BUFFER_CAPACITY_IN_BITS: usize = 128;
+
+impl BucketsRecordBatchBuilder {
+    /// Create a new instance of `BucketsRecordBatchBuilder`
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            offset: Int32ArrayBuilder::new(ArrayOptions {
+                optional: true,
+                dictionary_options: None,
+                ..Default::default()
+            }),
+            bucket_counts: LargeListBuilder::new(PrimitiveBuilder::new()),
+            nulls: NullBufferBuilder::new(NULL_BUFFER_CAPACITY_IN_BITS),
+        }
+    }
+
+    /// Append a new value.
+    pub fn append(&mut self, val: Option<(i32, &[u64])>) {
+        match val {
+            Some((offset, bucket_counts)) => {
+                self.offset.append_value(&offset);
+                self.bucket_counts
+                    .append_value(bucket_counts.iter().copied().map(Some));
+                self.nulls.append_non_null();
+            }
+            None => {
+                self.offset.append_value(&0);
+                self.bucket_counts.append_value(std::iter::empty());
+                self.nulls.append_null();
+            }
+        }
+    }
+
+    /// Construct an OTAP ExponentialHistogramDataPointsBuckets RecordBatch from the builders.
+    pub fn finish(&mut self) -> Result<StructArray, ArrowError> {
+        let mut fields = Vec::with_capacity(2);
+        let mut columns = Vec::with_capacity(2);
+
+        if let Some(array) = self.offset.finish() {
+            fields.push(Field::new(
+                consts::EXP_HISTOGRAM_OFFSET,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(array);
+        }
+
+        let array = self.bucket_counts.finish();
+        if !array.is_empty() {
+            fields.push(Field::new(
+                consts::EXP_HISTOGRAM_BUCKET_COUNTS,
+                array.data_type().clone(),
+                false,
+            ));
+            columns.push(Arc::new(array));
+        }
+
+        let length = self.nulls.len();
+        let nulls = self.nulls.finish();
+
+        StructArray::try_new_with_length(Fields::from(fields), columns, nulls, length)
+    }
+}


### PR DESCRIPTION
This change is similar to previous work done for logs (#625) and traces (#691) but metrics are larger and messier.

There are a few bits that I still need to clean up, but given the size of the change, I wanted to get it front of folks for reviewing sooner rather than later. Specifically, I'd like to:
* add some tests
* double check OTAP storage semantics in a few places where I found them confusing
* use the recently added `append_many` functionality to replace some `(0..metric_count).for_each` calls.